### PR TITLE
response-ready: invert check for installed callback

### DIFF
--- a/lib/response.ml
+++ b/lib/response.ml
@@ -139,7 +139,7 @@ module Body = struct
 
   let when_ready_to_write t callback =
     if is_closed t then callback ();
-    if t.when_ready_to_write == default_ready_to_write
-    then failwith "Response.Body: only one callback can be registered at a time";
+    if not (t.when_ready_to_write == default_ready_to_write)
+    then failwith "Response.Body.when_ready_to_write: only one callback can be registered at a time";
     t.when_ready_to_write <- callback
 end


### PR DESCRIPTION
If the default callback is the active one, then it can be overridden. Exactly the opposite behavior of the previous version of the code.

Related to #5