### PR TITLE
parser invariant

### DIFF
--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -214,7 +214,7 @@ module Reader = struct
 
   let parser handler =
     let ok = return (Ok ()) in
-    request >>= fun request ->
+    request <* commit >>= fun request ->
     match Request.body_length request with
     | `Error `Bad_request -> return (Error (`Bad_request request))
     | `Fixed 0L  ->


### PR DESCRIPTION
It was unclear when and where the buffer read/write window was being updated, which caused assertion errors in the code after the last refactoring. This commit makes it clear that `report_read_result` is responsible for zeroing out the "committed" byte count in the parser state, and shifting the read/write window of the input buffer accordingly.