### PR TITLE
upgrade-af: conform to new angstrom/faraday interfaces

### DIFF
--- a/httpaf-async.opam
+++ b/httpaf-async.opam
@@ -15,6 +15,7 @@ build-test: [
 ]
 depends: [
   "jbuilder" {build & >= "1.0+beta10"}
+  "angstrom-async"
   "async"
   "httpaf"
 ]

--- a/httpaf-async.opam
+++ b/httpaf-async.opam
@@ -16,6 +16,7 @@ build-test: [
 depends: [
   "jbuilder" {build & >= "1.0+beta10"}
   "angstrom-async"
+  "faraday-async"
   "async"
   "httpaf"
 ]

--- a/httpaf.opam
+++ b/httpaf.opam
@@ -14,7 +14,6 @@ build-test: [
 ]
 depends: [
   "jbuilder" {build & >= "1.0+beta10"}
-  "alcotest" {test & >= "0.4.1" & < "0.8.0"}
   "angstrom" {>= "0.7.0"}
   "faraday"  {>= "0.5.0"}
   "result"

--- a/httpaf.opam
+++ b/httpaf.opam
@@ -15,8 +15,8 @@ build-test: [
 depends: [
   "jbuilder" {build & >= "1.0+beta10"}
   "alcotest" {test & >= "0.4.1" & < "0.8.0"}
-  "angstrom" {>= "0.5.0"}
-  "faraday"  {>= "0.2.0"}
+  "angstrom" {>= "0.7.0"}
+  "faraday"  {>= "0.5.0"}
   "result"
 ]
 available: [ ocaml-version >= "4.03.0" ]

--- a/lib/httpaf.mli
+++ b/lib/httpaf.mli
@@ -467,7 +467,7 @@ module Request : sig
     val schedule_read
       :  t
       -> on_eof  : (unit -> unit)
-      -> on_read : (IOVec.buffer -> off:int -> len:int -> int)
+      -> on_read : (Bigstring.t -> off:int -> len:int -> int)
       -> unit
 
     val close : t -> unit
@@ -542,10 +542,6 @@ module Response : sig
         possible, this write will be combined with previous and/or subsequent
         writes before transmission. *)
 
-    val schedule_string : t -> ?off:int -> ?len:int -> string -> unit
-    (** [schedule_string w ?off ?len str] schedules [str] to be transmitted at
-        the next opportunity, without performing a copy. *)
-
     val schedule_bigstring : t -> ?off:int -> ?len:int -> Bigstring.t -> unit
     (** [schedule_bigstring w ?off ?len bs] schedules [bs] to be
         transmitted at the next opportunity without performing a copy. [bs]
@@ -613,12 +609,6 @@ end
 
 (** IOVec *)
 module IOVec : sig
-  type buffer =
-    [ `String of string
-    | `Bytes of Bytes.t
-    | `Bigstring of Bigstring.t
-  ] as 'a constraint 'a = Faraday.buffer
-
   type 'a t = 'a Faraday.iovec =
     { buffer : 'a
     ; off : int
@@ -711,7 +701,7 @@ module Connection : sig
       after {next_read_operation} returns a [`Yield] value. *)
 
   val next_write_operation : _ t -> [
-    | `Write of IOVec.buffer IOVec.t list
+    | `Write of Bigstring.t IOVec.t list
     | `Yield
     | `Close of int ]
   (** [next_write_operation t] returns a value describing the next operation

--- a/lib/iOVec.ml
+++ b/lib/iOVec.ml
@@ -32,8 +32,6 @@
   ----------------------------------------------------------------------------*)
 
 
-type buffer = Faraday.buffer
-
 type 'a t = 'a Faraday.iovec =
   { buffer : 'a
   ; off : int

--- a/lib/reqd.ml
+++ b/lib/reqd.ml
@@ -129,7 +129,7 @@ let respond_with_string t response str =
   | Waiting when_done_waiting ->
     (* XXX(seliopou): check response body length *)
     Writer.write_response  t.writer response;
-    Writer.schedule_string t.writer str;
+    Writer.write_string t.writer str;
     if t.persistent then
       t.persistent <- Response.persistent_connection response;
     t.response_state <- Complete response;

--- a/lib/request.ml
+++ b/lib/request.ml
@@ -66,14 +66,13 @@ let pp_hum fmt { meth; target; version; headers } =
 
 module Body = struct
   type bigstring = Bigstring.t
-  type buffer = IOVec.buffer
   type 'a iovec = 'a IOVec.t
 
   type t =
     { faraday            : Faraday.t
     ; mutable scheduled  : bool
     ; mutable on_eof     : unit -> unit
-    ; mutable on_read    : IOVec.buffer -> off:int -> len:int -> int
+    ; mutable on_read    : Bigstring.t -> off:int -> len:int -> int
     }
 
   let default_on_eof  = Sys.opaque_identity (fun () -> ())

--- a/lib/response.ml
+++ b/lib/response.ml
@@ -112,9 +112,6 @@ module Body = struct
    * be necessary. *)
     Faraday.write_bigstring ?off ?len t.faraday b
 
-  let schedule_string t ?off ?len s =
-    Faraday.schedule_string ?off ?len t.faraday s
-
   let schedule_bigstring t ?off ?len (b:Bigstring.t) =
     Faraday.schedule_bigstring ?off ?len t.faraday b
 

--- a/lib/serialize.ml
+++ b/lib/serialize.ml
@@ -75,10 +75,6 @@ let write_string_chunk t chunk =
   write_chunk_length t (String.length chunk);
   write_string       t chunk
 
-let schedule_string_chunk t chunk =
-  write_chunk_length t (String.length chunk);
-  schedule_string    t chunk
-
 let write_bigstring_chunk t chunk =
   write_chunk_length t (Bigstring.length chunk);
   write_bigstring    t chunk
@@ -141,21 +137,12 @@ module Writer = struct
   let write_bigstring t ?off ?len bigstring =
     write_bigstring t.encoder ?off ?len bigstring
 
-  let schedule_string t ?off ?len string =
-    schedule_string t.encoder ?off ?len string
-
-  let schedule_bytes t ?off ?len bytes =
-    schedule_bytes t.encoder ?off ?len bytes
-
   let schedule_bigstring t ?off ?len bigstring =
     schedule_bigstring t.encoder ?off ?len bigstring
 
   let schedule_fixed t iovecs =
     List.iter (fun { IOVec.buffer; off; len } ->
-      match buffer with
-      | `String    s  -> schedule_string    t ~off ~len s
-      | `Bytes     b  -> schedule_bytes     t ~off ~len b
-      | `Bigstring bs -> schedule_bigstring t ~off ~len bs)
+      schedule_bigstring t ~off ~len buffer)
     iovecs
 
   let schedule_chunk t iovecs =
@@ -192,5 +179,5 @@ module Writer = struct
     | `Yield -> `Yield
     | `Writev iovecs ->
       assert (not (t.closed));
-      `Write ((iovecs:IOVec.buffer IOVec.t list))
+      `Write iovecs
 end

--- a/lib_test/test_httpaf.ml
+++ b/lib_test/test_httpaf.ml
@@ -45,10 +45,7 @@ let output_stream_to_strings is =
   loop is []
 
 let iovec_to_string { IOVec.buffer; off; len } =
-  match buffer with
-  | `String x    -> String.sub x off len
-  | `Bytes  x    -> Bytes.(to_string (sub x off len))
-  | `Bigstring x -> Bigstring.to_string ~off ~len x
+  Bigstring.to_string ~off ~len buffer
 
 let test ~msg ~input ~output ~handler =
   let input  = input_stream_to_strings input in
@@ -151,11 +148,7 @@ let () =
     let request_body  = Reqd.request_body reqd in
     let response_body = Reqd.respond_with_streaming reqd (Response.create ~headers:Headers.(of_list ["connection", "close"]) `OK) in
     let rec on_read buffer ~off ~len =
-      begin match buffer with
-      | `Bigstring bs -> Response.Body.schedule_string response_body (Bigstring.to_string ~off ~len bs)
-      | `String s     -> Response.Body.schedule_string response_body ~off ~len s
-      | `Bytes bs     -> Response.Body.schedule_string response_body ~off ~len (Bytes.to_string bs)
-      end;
+      Response.Body.write_string response_body (Bigstring.to_string ~off ~len buffer);
       Response.Body.flush response_body (fun () ->
         Request.Body.schedule_read request_body ~on_eof ~on_read);
       len

--- a/lib_test/test_httpaf.ml
+++ b/lib_test/test_httpaf.ml
@@ -119,9 +119,12 @@ let test ~msg ~input ~output ~handler =
   in
   debug ("=== " ^ msg);
   let test_output = loop conn input in
-  print_endline (String.concat "|" output);
-  print_endline (String.concat "|" test_output);
+  let output = String.concat "" output in
+  let test_output = String.concat "" test_output in
+  print_endline output;
+  print_endline test_output;
   assert (output = test_output)
+;;
 
 let () =
   let handler body reqd =


### PR DESCRIPTION
There is one performance regression that's been introduced. This will require a new, low-level parser in Angstrom in order to avoid some copies.

Regression caused by inhabitedtype/angstrom#97, may be resolved in part by inhabitedtype/angstrom#99.