### PR TITLE
conn-create: make request handler a non-labeled argument

### DIFF
--- a/async/httpaf_async.ml
+++ b/async/httpaf_async.ml
@@ -43,7 +43,7 @@ let create_connection_handler ?config ~request_handler ~error_handler =
     let writev = Faraday_async.writev_of_fd fd in
     let request_handler = request_handler client_addr in
     let error_handler   = error_handler client_addr in
-    let conn = Connection.create ?config ~error_handler ~request_handler in
+    let conn = Connection.create ?config ~error_handler request_handler in
     let read_complete = Ivar.create () in
     let rec reader_thread () =
       match Connection.next_read_operation conn with

--- a/lib/connection.ml
+++ b/lib/connection.ml
@@ -126,7 +126,7 @@ let default_error_handler ?request error handle =
   Response.Body.write_string body message;
   Response.Body.close body
 
-let create ?(config=Config.default) ?(error_handler=default_error_handler) ~request_handler =
+let create ?(config=Config.default) ?(error_handler=default_error_handler) request_handler =
   let
     { Config
     . read_buffer_size

--- a/lib/httpaf.mli
+++ b/lib/httpaf.mli
@@ -674,7 +674,7 @@ module Connection : sig
   val create
     :  ?config:Config.t
     -> ?error_handler:error_handler
-    -> request_handler:('handle request_handler)
+    -> 'handle request_handler
     -> 'handle t
   (** [create ?config ?error_handler ~request_handler] creates a connection
       handler that will service individual requests with [request_handler]. *)


### PR DESCRIPTION
Making it a labeled argument along with a bunch of optional arguments requires the user to provide _all_ arguments, even if they're optional.