### PR TITLE
rm-META: remove unneeded META file

### DIFF
--- a/META.httpaf.template
+++ b/META.httpaf.template
@@ -1,6 +1,0 @@
-# JBUILDER_GEN
-
-package "async" (
-  description = "Deprecated. Use httpaf-async directly"
-  requires = "httpaf-async"
-)


### PR DESCRIPTION
There hasn't been an official release of httpaf yet, so the deprecation warning is not needed.