### PR TITLE
safe-string compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,11 @@ env:
   global:
   - PINS="httpaf-async:. httpaf:."
   matrix:
-  - PACKAGE="httpaf" DISTRO="ubuntu-16.04" OCAML_VERSION="4.04.2"
-  - PACKAGE="httpaf-async" DISTRO="ubuntu-16.04" OCAML_VERSION="4.04.2"
-  - PACKAGE="httpaf" DISTRO="alpine-3.5" OCAML_VERSION="4.03.0"
-  - PACKAGE="httpaf-async" DISTRO="alpine-3.5" OCAML_VERSION="4.03.0"
-  - PACKAGE="httpaf" DISTRO="debian-unstable" OCAML_VERSION="4.03.0"
+  - PACKAGE="httpaf"       DISTRO="ubuntu-16.04"    OCAML_VERSION="4.06.0"
+  - PACKAGE="httpaf-async" DISTRO="ubuntu-16.04"    OCAML_VERSION="4.06.0"
+  - PACKAGE="httpaf"       DISTRO="ubuntu-16.04"    OCAML_VERSION="4.04.2"
+  - PACKAGE="httpaf-async" DISTRO="ubuntu-16.04"    OCAML_VERSION="4.04.2"
+  - PACKAGE="httpaf"       DISTRO="alpine-3.5"      OCAML_VERSION="4.03.0"
+  - PACKAGE="httpaf-async" DISTRO="alpine-3.5"      OCAML_VERSION="4.03.0"
+  - PACKAGE="httpaf"       DISTRO="debian-unstable" OCAML_VERSION="4.03.0"
   - PACKAGE="httpaf-async" DISTRO="debian-unstable" OCAML_VERSION="4.03.0"

--- a/async/jbuild
+++ b/async/jbuild
@@ -1,7 +1,9 @@
 (jbuild_version 1)
 
 (library
- ((name httpaf_async)
+ ((name        httpaf_async)
   (public_name httpaf-async)
   (wrapped false)
-  (libraries (async core angstrom-async faraday-async httpaf))))
+  (libraries
+    (async core angstrom-async faraday-async httpaf))
+  (flags (:standard -safe-string))))

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -1,6 +1,8 @@
 (jbuild_version 1)
 
 (library
- ((name httpaf)
+ ((name        httpaf)
   (public_name httpaf)
-  (libraries (angstrom faraday result))))
+  (libraries
+    (angstrom faraday result))
+  (flags (:standard -safe-string))))


### PR DESCRIPTION
Add 4.06.0 to the build matrix.