### PR TITLE
Deliver EOF for request bodies

### DIFF
--- a/examples/async_echo_post.ml
+++ b/examples/async_echo_post.ml
@@ -1,0 +1,57 @@
+open Core
+open Async
+
+open Httpaf
+open Httpaf_async
+
+
+let error_handler _ ?request error start_response =
+  let response_body = start_response Headers.empty in
+  begin match error with
+  | `Exn exn ->
+    Response.Body.write_string response_body (Exn.to_string exn);
+    Response.Body.write_string response_body "\n";
+  | #Status.standard as error ->
+    Response.Body.write_string response_body (Status.default_reason_phrase error)
+  end;
+  Response.Body.close response_body
+;;
+
+let request_handler _ reqd =
+  match Reqd.request reqd  with
+  | { Request.meth = `POST; headers } ->
+    let response =
+      let content_type = Headers.get_exn headers "content-type" in
+      Response.create ~headers:(Headers.of_list ["content-type", content_type; "connection", "close"]) `OK
+    in
+    let request_body  = Reqd.request_body reqd in
+    let response_body = Reqd.respond_with_streaming reqd response in
+    let rec on_read buffer ~off ~len =
+      Response.Body.write_bigstring response_body buffer ~off ~len;
+      Request.Body.schedule_read request_body ~on_eof ~on_read;
+    and on_eof () =
+      print_endline "eof";
+      Response.Body.close response_body
+    in
+    Request.Body.schedule_read (Reqd.request_body reqd) ~on_eof ~on_read
+  | _ -> Reqd.respond_with_string reqd (Response.create `Method_not_allowed) ""
+;;
+
+let main port max_accepts_per_batch () =
+  Tcp.(Server.create_sock
+      ~backlog:10_000 ~max_connections:10_000 ~max_accepts_per_batch (on_port port))
+    (create_connection_handler ~request_handler ~error_handler)
+  >>= fun server ->
+  Deferred.never ()
+
+let () =
+  Command.async
+    ~summary:"Start a hello world Async server"
+    Command.Spec.(empty +>
+      flag "-p" (optional_with_default 8080 int)
+        ~doc:"int Source port to listen on"
+      +>
+      flag "-a" (optional_with_default 1 int)
+        ~doc:"int Maximum accepts per batch"
+    ) main
+  |> Command.run

--- a/examples/jbuild
+++ b/examples/jbuild
@@ -1,0 +1,4 @@
+(executables
+ ((libraries (httpaf httpaf-async async core))
+  (modules (async_echo_post))
+  (names (async_echo_post))))

--- a/lib/httpaf.mli
+++ b/lib/httpaf.mli
@@ -467,7 +467,7 @@ module Request : sig
     val schedule_read
       :  t
       -> on_eof  : (unit -> unit)
-      -> on_read : (Bigstring.t -> off:int -> len:int -> int)
+      -> on_read : (Bigstring.t -> off:int -> len:int -> unit)
       -> unit
 
     val close : t -> unit

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -153,7 +153,7 @@ let schedule_size writer n =
 let body ~encoding writer =
   let rec fixed n ~unexpected =
     if n = 0L
-    then unit
+    then finish writer
     else
       at_end_of_input
       >>= function

--- a/lib_test/test_httpaf.ml
+++ b/lib_test/test_httpaf.ml
@@ -145,7 +145,7 @@ let () =
   test ~msg:"Single OK w/body" ~handler:(handler "Hello, world!")
     ~input:[ `Request (Request.create ~headers:Headers.(of_list ["connection", "close"]) `GET "/")]
     ~output:[`Response (Response.create `OK); `Fixed "Hello, world!" ];
-  let echo reqd =
+  let echo got_eof reqd =
     debug " > handler called";
     let request_body  = Reqd.request_body reqd in
     let response_body = Reqd.respond_with_streaming reqd (Response.create ~headers:Headers.(of_list ["connection", "close"]) `OK) in
@@ -154,9 +154,11 @@ let () =
       Response.Body.flush response_body (fun () ->
         Request.Body.schedule_read request_body ~on_eof ~on_read);
       len
-    and on_eof () = Response.Body.close response_body in
+    and on_eof () = got_eof := true; Response.Body.close response_body in
     Request.Body.schedule_read request_body ~on_eof ~on_read;
   in
-  test ~msg:"POST" ~handler:echo
+  let got_eof = ref false in
+  test ~msg:"POST" ~handler:(echo got_eof)
     ~input:[`Request (Request.create `GET "/" ~headers:Headers.(of_list ["transfer-encoding", "chunked"])); `Chunk "This is a test"]
-    ~output:[`Response (Response.create `OK ~headers:Headers.(of_list ["connection", "close"])); `Fixed "This is a test"]
+    ~output:[`Response (Response.create `OK ~headers:Headers.(of_list ["connection", "close"])); `Fixed "This is a test"];
+  assert !got_eof

--- a/lib_test/test_httpaf.ml
+++ b/lib_test/test_httpaf.ml
@@ -152,8 +152,7 @@ let () =
     let rec on_read buffer ~off ~len =
       Response.Body.write_string response_body (Bigstring.to_string ~off ~len buffer);
       Response.Body.flush response_body (fun () ->
-        Request.Body.schedule_read request_body ~on_eof ~on_read);
-      len
+        Request.Body.schedule_read request_body ~on_eof ~on_read)
     and on_eof () = got_eof := true; Response.Body.close response_body in
     Request.Body.schedule_read request_body ~on_eof ~on_read;
   in


### PR DESCRIPTION
The parser did not close request bodes that had a fixed-length encoding. This pull request fixes that problem. Unfortunately that exposed a problem in the buffering logic for request input. So for the time being httpaf can't be used to buffer input as a result of partial reads. Hopefully this will be fixed in the future.

Closes #19.

@sgrove can you confirm the fix?