### PR TITLE
fix type of Response.body_length

### DIFF
--- a/lib/httpaf.mli
+++ b/lib/httpaf.mli
@@ -504,7 +504,7 @@ module Response : sig
     | `Fixed of Int64.t
     | `Chunked
     | `Close_delimited
-    | `Error of [`Bad_request | `Bad_gateway | `Internal_server_error ]
+    | `Error of [ `Bad_gateway | `Internal_server_error ]
   ]
   (** [body_length ?proxy ~request_method t] is the length of the message body
       accompanying [t] assuming it is a response to a request whose method was


### PR DESCRIPTION
`Response.body_length` could not return `Bad_request`.