### PR TITLE
fix-version-compare: fix major version comparison

### DIFF
--- a/lib/version.ml
+++ b/lib/version.ml
@@ -47,7 +47,7 @@ let to_buffer b t =
 
 let compare x y =
   let c = compare x.major y.major in
-  if c = 0 then c else compare x.minor y.minor
+  if c <> 0 then c else compare x.minor y.minor
 
 let to_string t =
   match t with


### PR DESCRIPTION
Return the major version comparison result when it is _not_ equal to zero, and otherwise return the minor version comparison result.