### PR TITLE
fix-shiftv: bounds check was reversed

### DIFF
--- a/lib/iOVec.ml
+++ b/lib/iOVec.ml
@@ -51,7 +51,7 @@ let rec shiftv iovecs n =
   | []            -> failwith "shiftv: n >= lengthv iovecs"
   | iovec::iovecs ->
     let len = length iovec in
-    if len >= n
+    if len <= n
     then shiftv iovecs (n - len)
     else (shift iovec len)::iovecs
 


### PR DESCRIPTION
shiftv should continue to loop when the current iovec is shorter than the amount that should be shifted. The code was doing the opposite before this change.