### PR TITLE
remove-switch: switching protocols not supported in this way

### DIFF
--- a/lib/httpaf.mli
+++ b/lib/httpaf.mli
@@ -628,15 +628,6 @@ module Reqd : sig
 
   val report_exn : _ t -> exn -> unit
   val try_with : _ t -> (unit -> unit) -> (unit, exn) result
-
-  (**/**)
-  (* This doesn't work yet *)
-  val switch_protocols
-    :  'handle t
-    -> headers:Headers.t
-    -> ('handle -> Bigstring.t -> unit)
-    -> unit
-  (**/**)
 end
 
 


### PR DESCRIPTION
It was never fully implemented to begin with so just remove the code.