### PR TITLE
Fix IOVec.shiftv (again)

### DIFF
--- a/lib/httpaf.mli
+++ b/lib/httpaf.mli
@@ -651,6 +651,8 @@ module IOVec : sig
 
   val shift  : 'a t -> int -> 'a t
   val shiftv : 'a t list -> int -> 'a t list
+
+  val pp_hum : Format.formatter -> _ t -> unit
 end
 
 (** {2 Request Descriptor} *)

--- a/lib/iOVec.ml
+++ b/lib/iOVec.ml
@@ -53,7 +53,7 @@ let rec shiftv iovecs n =
     let len = length iovec in
     if len <= n
     then shiftv iovecs (n - len)
-    else (shift iovec len)::iovecs
+    else (shift iovec n)::iovecs
 
 let add_len { buffer; off; len } n =
   { buffer; off; len = len + n }

--- a/lib/iOVec.ml
+++ b/lib/iOVec.ml
@@ -48,7 +48,7 @@ let rec shiftv iovecs n =
   if n = 0
   then iovecs
   else match iovecs with
-  | []            -> failwith "shiftv: n >= lengthv iovecs"
+  | []            -> failwith "shiftv: n > lengthv iovecs"
   | iovec::iovecs ->
     let len = length iovec in
     if len <= n

--- a/lib/iOVec.ml
+++ b/lib/iOVec.ml
@@ -50,9 +50,9 @@ let rec shiftv iovecs n =
   else match iovecs with
   | []            -> failwith "shiftv: n > lengthv iovecs"
   | iovec::iovecs ->
-    let len = length iovec in
-    if len <= n
-    then shiftv iovecs (n - len)
+    let iovec_len = length iovec in
+    if iovec_len <= n
+    then shiftv iovecs (n - iovec_len)
     else (shift iovec n)::iovecs
 
 let add_len { buffer; off; len } n =

--- a/lib/iOVec.ml
+++ b/lib/iOVec.ml
@@ -57,3 +57,6 @@ let rec shiftv iovecs n =
 
 let add_len { buffer; off; len } n =
   { buffer; off; len = len + n }
+
+let pp_hum fmt t =
+  Format.fprintf fmt "{ buffer = <opaque>; off = %d; len = %d }" t.off t.len

--- a/lib_test/test_httpaf.ml
+++ b/lib_test/test_httpaf.ml
@@ -6,28 +6,28 @@ module Version = struct
   let v1_0 = { major = 1; minor = 0 }
   let v1_1 = { major = 1; minor = 1 }
 
-  let compare () =
+  let test_compare () =
     Alcotest.(check int) "compare v1_1 v1_0" (compare v1_1 v1_0) 1;
     Alcotest.(check int) "compare v1_1 v1_1" (compare v1_1 v1_1) 0;
     Alcotest.(check int) "compare v1_0 v1_0" (compare v1_0 v1_0) 0;
     Alcotest.(check int) "compare v1_0 v1_1" (compare v1_0 v1_1) (-1);
   ;;
 
-  let to_string () =
+  let test_to_string () =
     Alcotest.(check string) "to_string v1_1" (to_string v1_1) "HTTP/1.1";
     Alcotest.(check string) "to_string v1_0" (to_string v1_0) "HTTP/1.0";
   ;;
 
   let tests =
-    [ "compare"  , `Quick, compare
-    ; "to_string", `Quick, to_string
+    [ "compare"  , `Quick, test_compare
+    ; "to_string", `Quick, test_to_string
     ]
 end
 
 module Method = struct
   include Method
 
-  let is_safe () =
+  let test_is_safe () =
     Alcotest.(check bool) "GET is safe"     (is_safe `GET )    true;
     Alcotest.(check bool) "HEAD is safe"    (is_safe `HEAD)    true;
     Alcotest.(check bool) "POST is safe"    (is_safe `POST)    false;
@@ -38,7 +38,7 @@ module Method = struct
     Alcotest.(check bool) "TRACE is safe"   (is_safe `TRACE  ) true;
   ;;
 
-  let is_cacheable () =
+  let test_is_cacheable () =
     Alcotest.(check bool) "GET is cacheable"     (is_cacheable `GET )    true;
     Alcotest.(check bool) "HEAD is cacheable"    (is_cacheable `HEAD)    true;
     Alcotest.(check bool) "POST is cacheable"    (is_cacheable `POST)    true;
@@ -49,7 +49,7 @@ module Method = struct
     Alcotest.(check bool) "TRACE is cacheable"   (is_cacheable `TRACE  ) false;
   ;;
 
-  let is_idempotent () =
+  let test_is_idempotent () =
     Alcotest.(check bool) "GET is idempotent"     (is_idempotent `GET )    true;
     Alcotest.(check bool) "HEAD is idempotent"    (is_idempotent `HEAD)    true;
     Alcotest.(check bool) "POST is idempotent"    (is_idempotent `POST)    false;
@@ -61,9 +61,9 @@ module Method = struct
   ;;
 
   let tests =
-    [ "is_safe"      , `Quick, is_safe
-    ; "is_cacheable" , `Quick, is_cacheable
-    ; "is_idempotent", `Quick, is_idempotent
+    [ "is_safe"      , `Quick, test_is_safe
+    ; "is_cacheable" , `Quick, test_is_cacheable
+    ; "is_idempotent", `Quick, test_is_idempotent
     ]
 end
 

--- a/lib_test/test_httpaf.ml
+++ b/lib_test/test_httpaf.ml
@@ -67,8 +67,49 @@ module Method = struct
     ]
 end
 
+module IOVec = struct
+  include IOVec
+
+  (* The length of the buffer is ignored by iovec operations *)
+  let buffer = Bigstring.create 0
+
+  let test_lengthv () =
+    Alcotest.(check int) "lengthv [] = 0"                 (lengthv []) 0;
+    Alcotest.(check int) "lengthv [iovec] = length iovec"
+      (lengthv [{ buffer; off = 0; len = 0 }]) (length {buffer; off = 0; len = 0 });
+    Alcotest.(check int) "lengthv [iovec] = length iovec"
+      (lengthv [{ buffer; off = 0; len = 10 }]) (length {buffer; off = 0; len = 10 });
+  ;;
+
+  let test_shiftv_raises () =
+    let test f =
+      Alcotest.check_raises
+        "shiftv iovecs n raises when n > lengthv iovecs"
+        (Failure "shiftv: n > lengthv iovecs")
+      (fun () -> ignore (f ()))
+    in
+    test (fun () -> shiftv [] 1);
+    test (fun () -> shiftv [{ buffer; off = 0; len = 1 }] 2);
+    test (fun () -> shiftv [{ buffer; off = 0; len = 1 }; { buffer; off = 0; len = 1 }] 3);
+  ;;
+
+  let test_shiftv () =
+    Alcotest.(check (of_pp pp_hum |> list)) "shiftv [] 0 = []" (shiftv [] 0) [];
+    Alcotest.(check (of_pp pp_hum |> list)) "shiftv [{... len ... }] len = []"
+      (shiftv [{ buffer; off = 0; len = 1 }] 1) [];
+    Alcotest.(check (of_pp pp_hum |> list)) "shiftv [iovec] n when length iovec < n"
+      (shiftv [{ buffer; off = 0; len = 4 }] 2) [{ buffer; off = 2; len = 2 }];
+  ;;
+
+  let tests =
+    [ "lengthv"       , `Quick, test_lengthv
+    ; "shiftv"        , `Quick, test_shiftv
+    ; "shiftv raises ", `Quick, test_shiftv_raises ]
+end
+
 let () =
   Alcotest.run "httpaf unit tests"
     [ "version" , Version.tests
     ; "method"  , Method.tests
+    ; "iovec"   , IOVec.tests
     ]


### PR DESCRIPTION
Pull request #33 purported to fix a bug, and did identify the presence of a bug, but did not completely address it. It was not sufficient to swap the comparison, but also modify the false branch to only shift off `n` from the iovec at the head of the list, rather than the length of the iovec itself.

This pull request adds tests demonstrating the bug, fixes the bug, and also fixes a misleading error message that came up while testing.