### PR TITLE
Fix chunked encoding

### DIFF
--- a/lib/body.ml
+++ b/lib/body.ml
@@ -1,10 +1,11 @@
 type _ t =
-  { faraday                     : Faraday.t
-  ; mutable scheduled           : bool
-  ; mutable on_eof              : unit -> unit
-  ; mutable on_read             : Bigstring.t -> off:int -> len:int -> unit
-  ; mutable when_ready_to_write : unit -> unit
-  ; buffered_bytes              : int ref
+  { faraday                        : Faraday.t
+  ; mutable read_scheduled         : bool
+  ; mutable write_final_if_chunked : bool
+  ; mutable on_eof                 : unit -> unit
+  ; mutable on_read                : Bigstring.t -> off:int -> len:int -> unit
+  ; mutable when_ready_to_write    : unit -> unit
+  ; buffered_bytes                 : int ref
   }
 
 let default_on_eof         = Sys.opaque_identity (fun () -> ())
@@ -13,11 +14,12 @@ let default_ready_to_write = Sys.opaque_identity (fun () -> ())
 
 let of_faraday faraday =
   { faraday
-  ; scheduled = false
-  ; on_eof    = default_on_eof
-  ; on_read   = default_on_read
-  ; when_ready_to_write = default_ready_to_write
-  ; buffered_bytes = ref 0
+  ; read_scheduled         = false
+  ; write_final_if_chunked = true
+  ; on_eof                 = default_on_eof
+  ; on_read                = default_on_read
+  ; when_ready_to_write    = default_ready_to_write
+  ; buffered_bytes         = ref 0
   }
 
 let create buffer =
@@ -66,35 +68,42 @@ let rec do_execute_read t on_eof on_read =
   match Faraday.operation t.faraday with
   | `Yield           -> ()
   | `Close           ->
-    t.scheduled <- false;
-    t.on_eof    <- default_on_eof;
-    t.on_read   <- default_on_read;
+    t.read_scheduled <- false;
+    t.on_eof         <- default_on_eof;
+    t.on_read        <- default_on_read;
     on_eof ()
   | `Writev []       -> assert false
   | `Writev (iovec::_) ->
-    t.scheduled <- false;
-    t.on_eof    <- default_on_eof;
-    t.on_read   <- default_on_read;
+    t.read_scheduled <- false;
+    t.on_eof         <- default_on_eof;
+    t.on_read        <- default_on_read;
     let { IOVec.buffer; off; len } = iovec in
     Faraday.shift t.faraday len;
     on_read buffer ~off ~len;
     execute_read t
 and execute_read t =
-  if t.scheduled then do_execute_read t t.on_eof t.on_read
+  if t.read_scheduled then do_execute_read t t.on_eof t.on_read
 
 let schedule_read t ~on_eof ~on_read =
-  if t.scheduled
+  if t.read_scheduled
   then failwith "Body.schedule_read: reader already scheduled";
   if is_closed t
   then do_execute_read t on_eof on_read
   else begin
-    t.scheduled <- true;
-    t.on_eof    <- on_eof;
-    t.on_read   <- on_read
+    t.read_scheduled <- true;
+    t.on_eof         <- on_eof;
+    t.on_read        <- on_read
   end
 
 let has_pending_output t =
-  Faraday.has_pending_output t.faraday
+  (* Force another write poll to make sure that the final chunk is emitted for
+   * chunk-encoded bodies. 
+   *
+   * XXX(seliopou): Note that the body data type does not keep track of
+   * encodings, so this happens even for non-chunk-encoded bodies. This should
+   * only happen for chunk-encoded bodies, but that's a fix for another day. *)
+  Faraday.has_pending_output t.faraday 
+  || (Faraday.is_closed t.faraday && t.write_final_if_chunked)
 
 let close_reader t =
   Faraday.close t.faraday;
@@ -110,7 +119,16 @@ let when_ready_to_write t callback =
 let transfer_to_writer_with_encoding t ~encoding writer =
   let faraday = t.faraday in
   begin match Faraday.operation faraday with
-  | `Yield | `Close -> ()
+  | `Yield -> ()
+  | `Close ->
+    let must_write_the_final_chunk = t.write_final_if_chunked in
+    t.write_final_if_chunked <- false;
+    if must_write_the_final_chunk
+    then
+      begin match encoding with
+      | `Chunked                    -> Serialize.Writer.schedule_chunk writer []
+      | `Fixed _ | `Close_delimited -> ()
+      end
   | `Writev iovecs ->
     let buffered = t.buffered_bytes in
     let iovecs   = IOVec.shiftv  iovecs !buffered in

--- a/lib/body.ml
+++ b/lib/body.ml
@@ -1,3 +1,36 @@
+(*----------------------------------------------------------------------------
+    Copyright (c) 2018 Inhabited Type LLC.
+
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    3. Neither the name of the author nor the names of his contributors
+       may be used to endorse or promote products derived from this software
+       without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE CONTRIBUTORS ``AS IS'' AND ANY EXPRESS
+    OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+    ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+    OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+    HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+    STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+  ----------------------------------------------------------------------------*)
+
 type _ t =
   { faraday                        : Faraday.t
   ; mutable read_scheduled         : bool

--- a/lib/body.ml
+++ b/lib/body.ml
@@ -54,9 +54,10 @@ let flush t kontinue =
 let is_closed t =
   Faraday.is_closed t.faraday
 
-let close t =
+let close_writer t =
   Faraday.close t.faraday;
-  ready_to_write t
+  ready_to_write t;
+;;
 
 let unsafe_faraday t =
   t.faraday
@@ -94,6 +95,11 @@ let schedule_read t ~on_eof ~on_read =
 
 let has_pending_output t =
   Faraday.has_pending_output t.faraday
+
+let close_reader t =
+  Faraday.close t.faraday;
+  execute_read t
+;;
 
 let when_ready_to_write t callback =
   if is_closed t then callback ();

--- a/lib/client_connection.ml
+++ b/lib/client_connection.ml
@@ -91,16 +91,15 @@ module Oneshot = struct
       Body.transfer_to_writer_with_encoding t.request_body ~encoding t.writer
   ;;
 
-
   let shutdown t =
     flush_request_body t;
     Reader.close t.reader;
     Writer.close t.writer;
-    Body.close t.request_body;
+    Body.close_writer t.request_body;
     begin match !(t.state) with
     | Awaiting_response | Closed -> ()
     | Received_response(_, response_body) ->
-      Body.close        response_body;
+      Body.close_reader response_body;
       Body.execute_read response_body;
     end;
   ;;

--- a/lib/httpaf.mli
+++ b/lib/httpaf.mli
@@ -493,8 +493,12 @@ module Body : sig
       whether those packets have been queued for deliver or have actually been
       received by the intended recipient. *)
 
-  val close : _ t -> unit
-  (** [close t] closes [t], causing subsequent read or write calls to raise. If
+  val close_reader : [`read] t -> unit
+  (** [close_reader t] closes [t], indicating that any subsequent input
+      received should be discarded. *)
+
+  val close_writer : [`write] t -> unit
+  (** [close_writer t] closes [t], causing subsequent write calls to raise. If
       [t] is writable, this will cause any pending output to become available
       to the output channel. *)
 

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -137,7 +137,7 @@ let swallow_trailer =
   skip_many header *> eol *> commit
 
 let finish writer =
-  Body.close writer;
+  Body.close_reader writer;
   commit
 
 let schedule_size writer n =

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -133,9 +133,6 @@ let response =
     (take_till P.is_cr    <* eol <* commit)
     (headers              <* eol)
 
-let swallow_trailer =
-  skip_many header *> eol *> commit
-
 let finish writer =
   Body.close_reader writer;
   commit
@@ -153,7 +150,7 @@ let schedule_size writer n =
 let body ~encoding writer =
   let rec fixed n ~unexpected =
     if n = 0L
-    then finish writer
+    then unit
     else
       at_end_of_input
       >>= function
@@ -168,21 +165,24 @@ let body ~encoding writer =
   match encoding with
   | `Fixed n ->
     fixed n ~unexpected:"expected more from fixed body"
+    >>= fun () -> finish writer
   | `Chunked ->
+    (* XXX(seliopou): The [eol] in this parser should really parse a collection
+     * of "chunk extensions", as defined in RFC7230§4.1. These do not show up
+     * in the wild very frequently, and the httpaf API has no way of exposing
+     * them to the suer, so for now the parser does not attempt to recognize
+     * them. This means that any chunked messages that contain chunk extensions
+     * will fail to parse. *)
     fix (fun p ->
       let _hex =
         (take_while1 P.is_hex >>= fun size -> hex size)
         (* swallows chunk-ext, if present, and CRLF *)
-        <* (skip_line *> commit)
+        <* (eol *> commit)
       in
-      at_end_of_input
-      >>= function
-        | true  -> finish writer
-        | false ->
-          _hex >>= fun size ->
-          if size = 0L
-          then finish writer *> swallow_trailer
-          else fixed size ~unexpected:"expected more from body chunk" *> p)
+      _hex >>= fun size ->
+      if size = 0L
+      then finish writer
+      else fixed size ~unexpected:"expected more from body chunk" *> eol *> p)
   | `Close_delimited ->
     fix (fun p ->
       let _rec = (available >>= fun n -> schedule_size writer n) *> p in

--- a/lib/reqd.ml
+++ b/lib/reqd.ml
@@ -174,7 +174,7 @@ let respond_with_streaming t response =
 
 let report_error t error =
   t.persistent <- false;
-  Body.close t.request_body;
+  Body.close_reader t.request_body;
   match t.response_state, t.error_code with
   | Waiting _, `Ok ->
     t.error_code <- (error :> [`Ok | error]);
@@ -191,9 +191,9 @@ let report_error t error =
      * has been reported as well. *)
     failwith "httpaf.Reqd.report_exn: NYI"
   | Streaming(_response, response_body), `Ok ->
-    Body.close response_body
+    Body.close_writer response_body
   | Streaming(_response, response_body), `Exn _ ->
-    Body.close response_body;
+    Body.close_writer response_body;
     Writer.close t.writer
   | (Complete _ | Streaming _ | Waiting _) , _ ->
     (* XXX(seliopou): Once additional logging support is added, log the error
@@ -209,7 +209,7 @@ let try_with t f : (unit, exn) Result.result =
 (* Private API, not exposed to the user through httpaf.mli *)
 
 let close_request_body { request_body; _ } =
-  Body.close request_body
+  Body.close_reader request_body
 
 let error_code t =
   match t.error_code with

--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -122,7 +122,8 @@ let default_error_handler ?request:_ error handle =
   in
   let body = handle Headers.empty in
   Body.write_string body message;
-  Body.close body
+  Body.close_writer body
+;;
 
 let create ?(config=Config.default) ?(error_handler=default_error_handler) request_handler =
   let

--- a/lib_test/simulator.ml
+++ b/lib_test/simulator.ml
@@ -137,7 +137,7 @@ let test_client ~request ~request_body_writes ~response_stream () =
   and oloop conn request_body =
     let request_body' =
       match request_body with
-      | []      -> Body.close body; request_body
+      | []      -> Body.close_writer body; request_body
       | x :: xs -> Body.write_string body x; Body.flush body ignore; xs
     in
     match Client_connection.next_write_operation conn with

--- a/lib_test/test_httpaf_client.ml
+++ b/lib_test/test_httpaf_client.ml
@@ -7,15 +7,15 @@ let get  =
     , Simulator.test_client
         ~request:(Request.create `GET "/")
         ~request_body_writes:[]
-        ~response_stream:[ `Response (Response.create `OK) ]
+        ~response_stream:(`Response (Response.create `OK), `Empty)
   ; "GET with a response body, chunked encoding"
     , `Quick
     , Simulator.test_client
         ~request:(Request.create `GET "/")
         ~request_body_writes:[]
-        ~response_stream:[ `Response (Response.create `OK
-                                       ~headers:Headers.(of_list ["transfer-encoding", "chunked"]))
-                         ; `Chunk "Hello, world!"]
+        ~response_stream:(`Response (Response.create `OK
+                                       ~headers:Headers.(of_list ["transfer-encoding", "chunked"])),
+                           `Chunked ["Hello, world!"])
   ]
 
 let post = []

--- a/lib_test/test_httpaf_server.ml
+++ b/lib_test/test_httpaf_server.ml
@@ -3,7 +3,7 @@ open Httpaf
 let basic_handler body reqd =
   Simulator.debug " > handler called";
   let request_body = Reqd.request_body reqd in
-  Body.close request_body;
+  Body.close_reader request_body;
   Reqd.respond_with_string reqd (Response.create `OK) body;
 ;;
 
@@ -16,7 +16,7 @@ let echo_handler got_eof reqd =
     Body.write_string response_body (Bigstring.to_string ~off ~len buffer);
     Body.flush response_body (fun () ->
       Body.schedule_read request_body ~on_eof ~on_read)
-  and on_eof () = got_eof := true; Body.close response_body in
+  and on_eof () = got_eof := true; Body.close_writer response_body in
   Body.schedule_read request_body ~on_eof ~on_read;
 ;;
 

--- a/lib_test/test_httpaf_server.ml
+++ b/lib_test/test_httpaf_server.ml
@@ -53,6 +53,19 @@ let single_get =
                   ; `Fixed "This is a test"];
       Alcotest.(check bool "got eof" !got_eof true);
     end
+  ; "single GET with streaming body, multiple chunks"
+  , `Quick
+  , begin fun () ->
+      let got_eof = ref false in
+      Simulator.test_server ()
+        ~handler: (echo_handler got_eof)
+        ~input:   [ `Request (Request.create `POST "/" ~headers:Headers.(of_list ["transfer-encoding", "chunked"]))
+                  ; `Chunk "This is a test"
+                  ; `Chunk " ... that involves multiple chunks" ]
+        ~output:  [`Response (Response.create `OK ~headers:Headers.(of_list ["connection", "close"]))
+                  ; `Fixed "This is a test ... that involves multiple chunks"];
+      Alcotest.(check bool "got eof" !got_eof true);
+    end
   ]
 ;;
 


### PR DESCRIPTION
The parser failed to properly parse multiple chunks in a chunked encoding. This was due to a few different problems with the parser, which was ultimately a result of bad testing input in the test simulator. The bugs on the parsing side were:

* chunked request bodies were being closed prematurely by the `fixed` parser;
* the `CRLF` at the end of each chunk was not being consumed; and
* the parser was (incorrectly) expecting a `CRLF` after the final chunk.

There was a corresponding serialization side, in which chunked bodies were not emitting the final `0\r\n` chunk.

This pull request all of these bugs at once, as they're somewhat interrelated. See commit messages for a bit more detail.