### PR TITLE
Zero-copy read API

### DIFF
--- a/async/httpaf_async.ml
+++ b/async/httpaf_async.ml
@@ -1,6 +1,56 @@
 open Core
 open Async
 
+(** XXX(seliopou): Replace Angstrom.Buffered with a module like this, while
+    also supporting growing the buffer. Clients can use this to buffer and the
+    use the unbuffered interface for actually running the parser. *)
+module Buffer : sig
+  type t
+
+  val create   : int -> t
+
+  val get : t -> f:(Bigstring.t -> off:int -> len:int -> int) -> int
+  val put : t -> f:(Bigstring.t -> off:int -> len:int -> int) -> int
+end= struct
+  type t =
+    { buffer      : Bigstring.t
+    ; mutable off : int
+    ; mutable len : int }
+
+  let create size =
+    let buffer = Bigstring.create size in
+    { buffer; off = 0; len = 0 }
+  ;;
+
+  let compress t =
+    if t.len = 0
+    then begin
+      t.off <- 0;
+      t.len <- 0;
+    end else if t.off > 0
+    then begin
+      Bigstring.blit ~src:t.buffer ~src_pos:t.off ~dst:t.buffer ~dst_pos:0 ~len:t.len;
+      t.off <- 0;
+    end
+  ;;
+
+  let get t ~f =
+    let n = f t.buffer ~off:t.off ~len:t.len in
+    t.off <- t.off + n;
+    t.len <- t.len - n;
+    if t.len = 0
+    then t.off <- 0;
+    n
+  ;;
+
+  let put t ~f =
+    compress t;
+    let n = f t.buffer ~off:(t.off + t.len) ~len:(Bigstring.length t.buffer - t.len) in
+    t.len <- t.len + n;
+    n
+  ;;
+end
+
 let read fd buffer =
   let badfd fd = failwithf "read got back fd: %s" (Fd.to_string fd) () in
   let rec finish fd buffer result =
@@ -25,15 +75,17 @@ let read fd buffer =
       finish fd buffer
         (Fd.syscall fd ~nonblocking:true
           (fun file_descr ->
-            Unix.Syscall_result.Int.ok_or_unix_error_exn ~syscall_name:"read"
-              (Bigstring.read_assume_fd_is_nonblocking file_descr buffer)))
+            Buffer.put buffer ~f:(fun bigstring ~off ~len ->
+              Unix.Syscall_result.Int.ok_or_unix_error_exn ~syscall_name:"read"
+                (Bigstring.read_assume_fd_is_nonblocking file_descr bigstring ~pos:off ~len))))
     else
       Fd.syscall_in_thread fd ~name:"read"
-        (fun file_descr -> Bigstring.read file_descr buffer)
+        (fun file_descr ->
+          Buffer.put buffer ~f:(fun bigstring ~off ~len ->
+            Bigstring.read file_descr bigstring ~pos:off ~len))
       >>= fun result -> finish fd buffer result
   in
   go fd buffer
-
 
 open Httpaf
 
@@ -46,13 +98,23 @@ module Server = struct
       let error_handler   = error_handler client_addr in
       let conn = Server_connection.create ?config ~error_handler request_handler in
       let read_complete = Ivar.create () in
+      (* XXX(seliopou): Make this configurable *)
+      let buffer = Buffer.create 0x1000 in
       let rec reader_thread () =
         match Server_connection.next_read_operation conn with
-        | `Read buffer ->
+        | `Read ->
           (* Log.Global.printf "read(%d)%!" (Fd.to_int_exn fd); *)
-          read fd buffer >>> fun result ->
-            Server_connection.report_read_result conn result;
-            reader_thread ()
+          read fd buffer
+          >>> begin function
+            | `Eof  ->
+              Server_connection.shutdown_reader conn;
+              reader_thread ()
+            | `Ok _ ->
+              Buffer.get buffer ~f:(fun bigstring ~off ~len ->
+                Server_connection.read conn bigstring ~off ~len)
+              |> ignore;
+              reader_thread ()
+          end
         | `Yield  ->
           (* Log.Global.printf "read_yield(%d)%!" (Fd.to_int_exn fd); *)
           Server_connection.yield_reader conn reader_thread
@@ -100,13 +162,22 @@ module Client = struct
     let request_body, conn   =
       Client_connection.request request ~error_handler ~response_handler in
     let read_complete = Ivar.create () in
+    let buffer = Buffer.create 0x1000 in
     let rec reader_thread () =
       match Client_connection.next_read_operation conn with
-      | `Read buffer ->
+      | `Read ->
         (* Log.Global.printf "read(%d)%!" (Fd.to_int_exn fd); *)
-        read fd buffer >>> fun result ->
-          Client_connection.report_read_result conn result;
-          reader_thread ()
+        read fd buffer
+          >>> begin function
+            | `Eof  ->
+              Client_connection.shutdown_reader conn;
+              reader_thread ()
+            | `Ok _ ->
+              Buffer.get buffer ~f:(fun bigstring ~off ~len ->
+                Client_connection.read conn bigstring ~off ~len)
+              |> ignore;
+              reader_thread ()
+          end
       | `Close ->
         (* Log.Global.printf "read_close(%d)%!" (Fd.to_int_exn fd); *)
         Ivar.fill read_complete ();

--- a/benchmarks/wrk_async_benchmark.ml
+++ b/benchmarks/wrk_async_benchmark.ml
@@ -17,13 +17,13 @@ let error_handler _ ?request error start_response =
   | #Status.standard as error ->
     Body.write_string response_body (Status.default_reason_phrase error)
   end;
-  Body.close response_body
+  Body.close_writer response_body
 ;;
 
 let request_handler _ reqd =
   let { Request.target } = Reqd.request reqd in
   let request_body       = Reqd.request_body reqd in
-  Body.close request_body;
+  Body.close_reader request_body;
   match target with
   | "/" -> Reqd.respond_with_bigstring reqd (Response.create ~headers `OK) text;
   | _   -> Reqd.respond_with_string    reqd (Response.create `Not_found) "Route not found"

--- a/lib/httpaf.mli
+++ b/lib/httpaf.mli
@@ -727,6 +727,11 @@ module Server_connection : sig
       that the caller should conduct on behalf of the connection. *)
 
   val read : _ t -> Bigstring.t -> off:int -> len:int -> int
+  (** [read t bigstring ~off ~len] reads bytes of input from the provided range
+      of [bigstring] and returns the number of bytes consumed by the
+      connection.  {!read} should be called after {!next_read_operation}
+      returns a [`Read] value and additional input is available for the
+      connection to consume. *)
 
   val yield_reader : _ t -> (unit -> unit) -> unit
   (** [yield_reader t continue] registers with the connection to call
@@ -734,6 +739,11 @@ module Server_connection : sig
       after {next_read_operation} returns a [`Yield] value. *)
 
   val shutdown_reader : _ t -> unit
+  (** [shutdown_reader t] shutds own the read processor for the connection. All
+      subsequent calls to {!next_read_operations} will return [`Close].
+      {!shutdown_reader} should be called after {!next_read_operation} returns
+      a [`Read] value and there is no further input available for the
+      connection to consume. *)
 
   val next_write_operation : _ t -> [
     | `Write of Bigstring.t IOVec.t list
@@ -804,8 +814,18 @@ module Client_connection : sig
       that the caller should conduct on behalf of the connection. *)
 
   val read : t -> Bigstring.t -> off:int -> len:int -> int
+  (** [read t bigstring ~off ~len] reads bytes of input from the provided range
+      of [bigstring] and returns the number of bytes consumed by the
+      connection.  {!read} should be called after {!next_read_operation}
+      returns a [`Read] value and additional input is available for the
+      connection to consume. *)
 
   val shutdown_reader : t -> unit
+  (** [shutdown_reader t] shutds own the read processor for the connection. All
+      subsequent calls to {!next_read_operations} will return [`Close].
+      {!shutdown_reader} should be called after {!next_read_operation} returns
+      a [`Read] value and there is no further input available for the
+      connection to consume. *)
 
   val next_write_operation : t -> [
     | `Write of Bigstring.t IOVec.t list

--- a/lib_test/simulator.ml
+++ b/lib_test/simulator.ml
@@ -18,7 +18,7 @@ let body_to_strings = function
   | `Empty       -> []
   | `Fixed   xs  -> xs
   | `Chunked xs  ->
-    List.fold_right (fun x acc -> 
+    List.fold_right (fun x acc ->
       let len = String.length x in
       [Printf.sprintf "%x\r\n" len; x; "\r\n"] @ acc)
     xs [ "0\r\n" ]
@@ -37,13 +37,17 @@ let response_stream_to_body (`Response response, body) =
 let iovec_to_string { IOVec.buffer; off; len } =
   Bigstring.to_string ~off ~len buffer
 
+let bigstring_append_string bs s =
+  Bigstring.of_string (Bigstring.to_string bs ^ s)
+
+let bigstring_empty = Bigstring.of_string ""
 
 let test_server ~input ~output ~handler () =
-  let input  = List.(concat (map case_to_strings input)) in
-  let output = List.(concat (map case_to_strings output)) in
+  let reads  = List.(concat (map case_to_strings input)) in
+  let writes = List.(concat (map case_to_strings output)) in
   let conn   = Server_connection.create handler in
   let iwait, owait = ref false, ref false in
-  let rec loop conn input =
+  let rec loop conn input reads =
     if !iwait && !owait then
       assert false (* deadlock, at lest for test handlers. *);
     if Server_connection.is_closed conn
@@ -51,64 +55,64 @@ let test_server ~input ~output ~handler () =
       debug "state: closed";
       []
     end else begin
-      let input'  = iloop conn input in
-      let output  = oloop conn in
-      output @ loop conn input'
+      let input', reads' = iloop conn input reads in
+      let output         = oloop conn in
+      output @ loop conn input' reads'
     end
-  and iloop conn input =
+  and iloop conn input reads =
     if !iwait
-    then begin debug " iloop: wait"; input end
+    then begin debug " iloop: wait"; input, reads end
     else
-      match Server_connection.next_read_operation conn, input with
-      | `Read buffer, s::input' ->
-        debug " iloop: read";
-        let len = min (Bigstring.length buffer) (String.length s) in
-        Bigstring.blit_from_string s 0 buffer 0 len;
-        Server_connection.report_read_result conn (`Ok len);
-        if len = String.length s
-        then input'
-        else String.(sub s len (length s - len)) :: input'
-      | `Read _, [] ->
-        debug " iloop: eof";
-        Server_connection.report_read_result conn `Eof;
-        []
+      match Server_connection.next_read_operation conn, reads with
+      | `Read, read::reads' ->
+        debug " server iloop: read";
+        let input     = bigstring_append_string input read in
+        let input_len = Bigstring.length input in
+        let result    = Server_connection.read conn input ~off:0 ~len:input_len in
+        if result = input_len
+        then bigstring_empty, reads'
+        else Bigstring.sub ~off:result input, reads'
+      | `Read, [] ->
+        debug " server iloop: eof";
+        Server_connection.shutdown_reader conn;
+        bigstring_empty, []
       | _          , [] ->
-        debug " iloop: eof";
-        Server_connection.report_read_result conn `Eof;
-        []
+        debug " server iloop: eof";
+        Server_connection.shutdown_reader conn;
+        bigstring_empty, []
       | `Close    , _     ->
-        debug " iloop: close(ok)"; []
+        debug " server iloop: close(ok)"; input, []
       | `Yield , _  ->
-        debug " iloop: yield";
+        debug " server iloop: yield";
         iwait := true;
         Server_connection.yield_reader conn (fun () -> debug " iloop: continue"; iwait := false);
-        input
+        input, reads
   and oloop conn =
     if !owait
-    then (begin debug " oloop: wait"; [] end)
+    then (begin debug " server oloop: wait"; [] end)
     else
       match Server_connection.next_write_operation conn with
       | `Close _ ->
-        debug " oloop: closed"; []
+        debug " server oloop: closed"; []
       | `Yield ->
-        debug " oloop: yield";
+        debug " server oloop: yield";
         owait := true;
-        Server_connection.yield_writer conn (fun () -> debug " oloop: continue"; owait := false);
+        Server_connection.yield_writer conn (fun () -> debug " server oloop: continue"; owait := false);
         []
       | `Write iovecs ->
-        debug " oloop: write";
+        debug " server oloop: write";
         let output = List.map iovec_to_string iovecs in
         Server_connection.report_write_result conn (`Ok (IOVec.lengthv iovecs));
         output
   in
-  let test_output = loop conn input |> String.concat "" in
-  let output      = String.concat "" output in
+  let test_output = loop conn bigstring_empty reads |> String.concat "" in
+  let output      = String.concat "" writes in
   Alcotest.(check string "response" output test_output)
 ;;
 
 let test_client ~request ~request_body_writes ~response_stream () =
-  let input  = case_to_strings response_stream in
-  let output = case_to_strings (`Request request, `Fixed request_body_writes) in
+  let reads  = case_to_strings response_stream in
+  let writes = case_to_strings (`Request request, `Fixed request_body_writes) in
   let test_input  = ref []    in
   let got_eof     = ref false in
   let error_handler _ = assert false in
@@ -126,13 +130,13 @@ let test_client ~request ~request_body_writes ~response_stream () =
       ~error_handler
       ~response_handler
   in
-  let rec loop conn request_body_writes input =
+  let rec loop conn request_body_writes input reads =
     if Client_connection.is_closed conn
     then []
     else begin
-      let input'                       = iloop conn input in
+      let input', reads'               = iloop conn input reads in
       let output, request_body_writes' = oloop conn request_body_writes in
-      output @ loop conn request_body_writes' input'
+      output @ loop conn request_body_writes' input' reads'
     end
   and oloop conn request_body =
     let request_body' =
@@ -145,37 +149,38 @@ let test_client ~request ~request_body_writes ~response_stream () =
       (* This should only happen once to close the writer *)
       Client_connection.yield_writer conn ignore; [], request_body'
     | `Close _ ->
-      debug " oloop: closed"; [], request_body'
+      debug " client oloop: closed"; [], request_body'
     | `Write iovecs ->
-      debug " oloop: write";
+      debug " client oloop: write";
       let output = List.map iovec_to_string iovecs in
       Client_connection.report_write_result conn (`Ok (IOVec.lengthv iovecs));
       output, request_body'
-  and iloop conn input =
-    match Client_connection.next_read_operation conn, input with
-    | `Read buffer, s::input' ->
-      debug " iloop: read";
-      let len = min (Bigstring.length buffer) (String.length s) in
-      Bigstring.blit_from_string s 0 buffer 0 len;
-      Client_connection.report_read_result conn (`Ok len);
-      if len = String.length s
-      then input'
-      else String.(sub s len (length s - len)) :: input'
-    | `Read _, [] ->
-      debug " iloop: eof";
-      Client_connection.report_read_result conn `Eof;
-      []
+  and iloop conn input reads =
+    match Client_connection.next_read_operation conn, reads with
+    | `Read, read::reads' ->
+      debug " client iloop: read";
+      let input     = bigstring_append_string input read in
+      let input_len = Bigstring.length input in
+      let result     = Client_connection.read conn input ~off:0 ~len:input_len in
+      if result = input_len
+      then bigstring_empty, reads'
+      else Bigstring.sub ~off:result input, reads'
+    | `Read, [] ->
+      debug " client iloop: eof";
+      Client_connection.shutdown_reader conn;
+      input, []
     | _          , [] ->
-      debug " iloop: eof";
-      Client_connection.report_read_result conn `Eof;
-      []
+      debug " client iloop: eof";
+      Client_connection.shutdown_reader conn;
+      input, []
     | `Close    , _     ->
-      debug " iloop: close(ok)"; []
+      debug " client iloop: close(ok)";
+      input, []
   in
-  let test_output = loop conn request_body_writes input |> String.concat "" in
+  let test_output = loop conn request_body_writes bigstring_empty reads |> String.concat "" in
   let test_input  = List.rev !test_input |> String.concat "" in
   let input       = response_stream_to_body response_stream in
-  let output      = String.concat "" output in
+  let output      = String.concat "" writes in
   Alcotest.(check bool   "got eof"  true   !got_eof);
   Alcotest.(check string "request"  output test_output);
   Alcotest.(check string "response" input  test_input);


### PR DESCRIPTION
With the latest release of angstrom it's possible to implement a zero-copy read interface in httpaf, so that's what this pull request does.

Previously `next_read_operation` would indicate that more input was needed by returning a  `Read` variant, which would also contain a `Bigstring.t`. The caller would then have to blit any available input into that `Bigstring.t` and then report the read result by calling `report_read_result`.

The new interface simply returns a `Read` that has no additional arguments. This indicates that the caller should call `read` with the `Bigstring.t` containing the new input at a given offset and for the length specified, thus avoiding the copy that was necessary in the previous interface. If instead the caller has no further input (for example, because the input channel reported EOF), then `shutdown_reader` should be called instead of `read`.