### PR TITLE
Handle advancing the request queue for responses without intermediates bodies

### DIFF
--- a/lib/body.ml
+++ b/lib/body.ml
@@ -161,16 +161,15 @@ let transfer_to_writer_with_encoding t ~encoding writer =
       begin match encoding with
       | `Chunked                    -> Serialize.Writer.schedule_chunk writer []
       | `Fixed _ | `Close_delimited -> ()
-      end
+      end;
+    Serialize.Writer.flush writer (fun () -> Serialize.Writer.close writer)
   | `Writev iovecs ->
     let buffered = t.buffered_bytes in
     let iovecs   = IOVec.shiftv  iovecs !buffered in
     let lengthv  = IOVec.lengthv iovecs in
     buffered := !buffered + lengthv;
     begin match encoding with
-    | `Fixed _ | `Close_delimited -> 
-      t.write_final_if_chunked <- false;
-      Serialize.Writer.schedule_fixed writer iovecs
+    | `Fixed _ | `Close_delimited -> Serialize.Writer.schedule_fixed writer iovecs
     | `Chunked                    -> Serialize.Writer.schedule_chunk writer iovecs
     end;
     Serialize.Writer.flush writer (fun () ->

--- a/lib/body.ml
+++ b/lib/body.ml
@@ -168,7 +168,9 @@ let transfer_to_writer_with_encoding t ~encoding writer =
     let lengthv  = IOVec.lengthv iovecs in
     buffered := !buffered + lengthv;
     begin match encoding with
-    | `Fixed _ | `Close_delimited -> Serialize.Writer.schedule_fixed writer iovecs
+    | `Fixed _ | `Close_delimited -> 
+      t.write_final_if_chunked <- false;
+      Serialize.Writer.schedule_fixed writer iovecs
     | `Chunked                    -> Serialize.Writer.schedule_chunk writer iovecs
     end;
     Serialize.Writer.flush writer (fun () ->

--- a/lib/reqd.ml
+++ b/lib/reqd.ml
@@ -233,9 +233,9 @@ let persistent_connection t =
 let requires_input { request_body; _ } =
   not (Body.is_closed request_body)
 
-let requires_output { response_state; _ } =
+let requires_output { response_state; writer; _ } =
   match response_state with
-  | Complete _ -> false
+  | Complete _ -> Writer.has_pending_output writer;
   | Streaming (_, response_body) ->
     not (Body.is_closed response_body)
     || Body.has_pending_output response_body

--- a/lib/serialize.ml
+++ b/lib/serialize.ml
@@ -157,6 +157,9 @@ module Writer = struct
     | `Closed -> close t
     | `Ok len -> shift t.encoder len
 
+  let has_pending_output t =
+    Faraday.has_pending_output t.encoder
+
   let next t =
     match Faraday.operation t.encoder with
     | `Close         -> `Close (drained_bytes t)

--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -207,6 +207,9 @@ let advance_request_queue_if_necessary t =
     then if Reqd.is_complete reqd then begin
       ignore (Queue.take t.request_queue);
       wakeup_reader t;
+    end else if (Reqd.requires_output reqd)
+    then begin
+      wakeup_reader t;
     end else begin
       ignore (Queue.take t.request_queue);
       Queue.iter Reqd.close_request_body t.request_queue;

--- a/lib_test/test_httpaf_server.ml
+++ b/lib_test/test_httpaf_server.ml
@@ -27,7 +27,7 @@ let single_get =
         ~handler: (basic_handler "")
         ~input:   [(`Request (Request.create `GET "/")), `Empty]
         ~output:  [(`Response (Response.create `OK)   ), `Empty]
-  ; "singel GET, close connection"
+  ; "single GET, close connection"
     , `Quick
     , Simulator.test_server
         ~handler: (basic_handler "")


### PR DESCRIPTION
Currently for persistent connections, we're always trying to poll one
more write even if the response body isn't chunked. This causes weird
issues such as #37.

This PR attempts to fix this problematic behavior. I wasn't able to produce
a failing test, most likely because the test simulator always runs synchronously,
but it does fix the issue for me locally.