### PR TITLE
fix double callback in when_ready_to_write

### DIFF
--- a/lib/body.ml
+++ b/lib/body.ml
@@ -144,10 +144,11 @@ let close_reader t =
 ;;
 
 let when_ready_to_write t callback =
-  if is_closed t then callback ();
   if not (t.when_ready_to_write == default_ready_to_write)
-  then failwith "Body.when_ready_to_write: only one callback can be registered at a time";
-  t.when_ready_to_write <- callback
+  then failwith "Body.when_ready_to_write: only one callback can be registered at a time"
+  else if is_closed t
+  then callback ()
+  else t.when_ready_to_write <- callback
 
 let transfer_to_writer_with_encoding t ~encoding writer =
   let faraday = t.faraday in


### PR DESCRIPTION
When you yield a writer, the callback is either stored in one of three
places, or it is invoked immediately by `Body.when_ready_to_write`. The
immediate invocation happens if the body is closed, but that conditional
does not prevent the rest of the function from running. In some cases,
you may immediately invoke a callback, store it in
`t.when_ready_to_write`, and then later invoke it again later when that
field is checked.

This also moves the check for `t.when_ready_to_write` before the
synchronous invocation. In the case where we have a pending callback, it
would be nice for the two possible outcomes of `when_ready_to_write` to
behave similarly.