### PR TITLE
fix advancing request queue

### DIFF
--- a/lib/reqd.ml
+++ b/lib/reqd.ml
@@ -194,7 +194,7 @@ let report_error t error =
     Body.close_writer response_body
   | Streaming(_response, response_body), `Exn _ ->
     Body.close_writer response_body;
-    Writer.close t.writer
+    Writer.close_and_drain t.writer
   | (Complete _ | Streaming _ | Waiting _) , _ ->
     (* XXX(seliopou): Once additional logging support is added, log the error
      * in case it is not spurious. *)

--- a/lib/serialize.ml
+++ b/lib/serialize.ml
@@ -142,7 +142,10 @@ module Writer = struct
     Faraday.yield t.encoder
 
   let close t =
-    close t.encoder;
+    Faraday.close t.encoder
+
+  let close_and_drain t =
+    Faraday.close t.encoder;
     let drained = Faraday.drain t.encoder in
     t.drained_bytes <- t.drained_bytes + drained
 

--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -203,10 +203,11 @@ let report_exn t exn =
 let advance_request_queue_if_necessary t =
   if is_active t then begin
     let reqd = current_reqd_exn t in
-    if Reqd.persistent_connection reqd
-    then if Reqd.is_complete reqd then begin
-      ignore (Queue.take t.request_queue);
-      wakeup_reader t;
+    if Reqd.persistent_connection reqd then begin
+      if Reqd.is_complete reqd then begin
+        ignore (Queue.take t.request_queue);
+        wakeup_reader t;
+      end
     end else begin
       ignore (Queue.take t.request_queue);
       Queue.iter Reqd.close_request_body t.request_queue;


### PR DESCRIPTION
Due to a complicated chain of if/then/else expressions, the
`advance_request_queue_if_necessary` function was structured in such a
way that the branch to handle requests ending a persistent connection
was actually being applied to non-complete requests.

This fix exposed a bug in the tests where the `connection: close` header
would cause the request to be closed immediately. This was because
`Reqd.is_complete` is true as long as there is nothing to be read or
written -- that is, the request body is complete and the entire response
body has made it to `t.writer` but _not necessarily flushed_. Combine
this with the fact that the proceeding `shutdown` would close the
writer, causing it to be drained of pending writes, and you have
connections that close immediately.

We fix this by changing the behavior of shutdown. Now it only closes the
writer and does not drain it, which allows the external world to flush
it as normal. This is a nice fit, since as it is now, closing the reader
still allows the server to finish reading the request it is currently
working on.