### PR TITLE
Make `wait_for_first_flush` configurable in streaming responses

### DIFF
--- a/lib/httpaf.mli
+++ b/lib/httpaf.mli
@@ -681,7 +681,7 @@ module Reqd : sig
 
   val respond_with_string    : _ t -> Response.t -> string -> unit
   val respond_with_bigstring : _ t -> Response.t -> Bigstring.t -> unit
-  val respond_with_streaming : _ t -> Response.t -> [`write] Body.t
+  val respond_with_streaming : ?wait_for_first_flush:bool -> _ t -> Response.t -> [`write] Body.t
 
   (** Exception Handling *)
 

--- a/lib/httpaf.mli
+++ b/lib/httpaf.mli
@@ -681,7 +681,7 @@ module Reqd : sig
 
   val respond_with_string    : _ t -> Response.t -> string -> unit
   val respond_with_bigstring : _ t -> Response.t -> Bigstring.t -> unit
-  val respond_with_streaming : ?wait_for_first_flush:bool -> _ t -> Response.t -> [`write] Body.t
+  val respond_with_streaming : ?flush_headers_immediately:bool -> _ t -> Response.t -> [`write] Body.t
 
   (** Exception Handling *)
 

--- a/lib/reqd.ml
+++ b/lib/reqd.ml
@@ -148,7 +148,7 @@ let respond_with_bigstring t response (bstr:Bigstring.t) =
     failwith "httpaf.Reqd.respond_with_bigstring: response already complete"
 
 let unsafe_respond_with_streaming ~flush_headers_immediately t response =
-  t.wait_for_first_flush <- flush_headers_immediately;
+  t.wait_for_first_flush <- not flush_headers_immediately;
   match t.response_state with
   | Waiting when_done_waiting ->
     let response_body = Body.create t.response_body_buffer in
@@ -164,7 +164,7 @@ let unsafe_respond_with_streaming ~flush_headers_immediately t response =
   | Complete _ ->
     failwith "httpaf.Reqd.respond_with_streaming: response already complete"
 
-let respond_with_streaming ?(flush_headers_immediately=true) t response =
+let respond_with_streaming ?(flush_headers_immediately=false) t response =
   if t.error_code <> `Ok then
     failwith "httpaf.Reqd.respond_with_streaming: invalid state, currently handling error";
   unsafe_respond_with_streaming ~flush_headers_immediately t response
@@ -181,7 +181,7 @@ let report_error t error =
       | #Status.standard as status -> status
     in
     t.error_handler ~request:t.request error (fun headers ->
-      unsafe_respond_with_streaming ~flush_headers_immediately:false t (Response.create ~headers status))
+      unsafe_respond_with_streaming ~flush_headers_immediately:true t (Response.create ~headers status))
   | Waiting _, `Exn _ ->
     (* XXX(seliopou): Decide what to do in this unlikely case. There is an
      * outstanding call to the [error_handler], but an intervening exception


### PR DESCRIPTION
This is related to #65. I managed to get websockets working using
Conduit in order to gain access to the file descriptors. However,
because streaming responses wait for the first write to flush response
bodies, I could never deliver the connection upgrade with 1. an empty
response body and 2. while not closing the writer.

Making `wait_for_first_flush` configurable (which I see was already in
the roadmap) solves this problem.

I've tested this in my code and it's working really well now. Please
let me know if you had thought of another way of configuring this
behavior.