### PR TITLE
Minor fix: Synopsis should start with a capital and not end with a dot

### DIFF
--- a/httpaf.opam
+++ b/httpaf.opam
@@ -19,7 +19,7 @@ depends: [
   "result"
 ]
 synopsis:
-  "A high-performance, memory-efficient, and scalable web server for OCaml."
+  "A high-performance, memory-efficient, and scalable web server for OCaml"
 description: """
 http/af implements the HTTP 1.1 specification with respect to parsing,
 serialization, and connection pipelining as a state machine that is agnostic to


### PR DESCRIPTION
This fixes OPAM's warning 47:

```
[WARNING] Failed checks in opam file from upstream of httpaf:
  warning 47: Synopsis should start with a capital and not end with a dot
```