### PR TITLE
Catch parse errors and hand them to error_handler

### DIFF
--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -310,12 +310,17 @@ module Reader = struct
     ignore (read_with_more t Bigstringaf.empty ~off:0 ~len:0 Complete : int);
   ;;
 
+  let is_parse_failure t =
+    match t.parse_state with
+    | Fail _ -> true
+    | _ -> false
+
   let next t =
     match t.parse_state with
     | Done ->
       if t.closed
       then `Close
       else `Read
-    | Fail    _ -> `Close
+    | Fail failure -> `Error failure
     | Partial _ -> `Read
 end

--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -184,7 +184,7 @@ let set_error_and_handle ?request t error =
     t.error_handler ?request error (fun headers ->
       Writer.write_response writer (Response.create ~headers status);
       Body.of_faraday (Writer.faraday writer));
-    shutdown_writer t;
+    wakeup_writer t;
   end
 
 let report_exn t exn =

--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -184,6 +184,7 @@ let set_error_and_handle ?request t error =
     t.error_handler ?request error (fun headers ->
       Writer.write_response writer (Response.create ~headers status);
       Body.of_faraday (Writer.faraday writer));
+    shutdown_writer t;
   end
 
 let report_exn t exn =
@@ -210,7 +211,7 @@ let advance_request_queue_if_necessary t =
       else if not (Reqd.requires_input reqd)
       then shutdown_reader t
     end
-  end else if Reader.is_closed t.reader
+  end else if Reader.is_closed t.reader && (not (Reader.is_parse_failure t.reader))
   then shutdown t
 
 let _next_read_operation t =


### PR DESCRIPTION
refs #18.

This diff propagates parser errors to the request handling logic in order to give the user a chance to gracefully handle the error in `error_handler`. Previously httpaf was just swallowing these errors, e.g. `curl` would fail with `curl: (52) Empty reply from server` (this can be seen in the both echo examples in the repo).

I added tests for 2 cases I was seeing:
1. a malformed / rejected request, such as whitespace before a header's `:`, as per (comment in the codebase):
> From RFC7230§3.2.4:
>       "No whitespace is allowed between the header field-name and colon.
2. EOF in the HTTP Request, which mirrors the issue @sgrove reported in #18 