### PR TITLE
Support pluggable read and writev in async / lwt bindings

### DIFF
--- a/async/httpaf_async.ml
+++ b/async/httpaf_async.ml
@@ -83,10 +83,15 @@ let read fd buffer =
 open Httpaf
 
 module Server = struct
-  let create_connection_handler ?config ~request_handler ~error_handler =
+  let create_connection_handler
+    ?config
+    ?(writev=Faraday_async.writev_of_fd)
+    ?(read=read)
+    ~request_handler
+    ~error_handler =
     fun client_addr socket ->
       let fd     = Socket.fd socket in
-      let writev = Faraday_async.writev_of_fd fd in
+      let writev = writev fd in
       let request_handler = request_handler client_addr in
       let error_handler   = error_handler client_addr in
       let conn = Server_connection.create ?config ~error_handler request_handler in

--- a/async/httpaf_async.mli
+++ b/async/httpaf_async.mli
@@ -15,6 +15,12 @@ end
 module Server : sig
   val create_connection_handler
     :  ?config         : Server_connection.Config.t
+    -> ?writev:(Async.Fd.t
+                -> Faraday.bigstring Faraday.iovec list
+                -> [ `Ok of int | `Closed ] Async.Deferred.t)
+    -> ?read:(Async.Fd.t
+              -> Buffer.t
+              -> [ `Eof | `Ok of int ] Async.Deferred.t)
     -> request_handler : ('a -> Fd.t Server_connection.request_handler)
     -> error_handler   : ('a -> Server_connection.error_handler)
     -> ([< Socket.Address.t] as 'a)

--- a/async/httpaf_async.mli
+++ b/async/httpaf_async.mli
@@ -3,6 +3,15 @@ open Async
 
 open Httpaf
 
+module Buffer : sig
+  type t
+
+  val create   : int -> t
+
+  val get : t -> f:(Bigstring.t -> off:int -> len:int -> int) -> int
+  val put : t -> f:(Bigstring.t -> off:int -> len:int -> int) -> int
+end
+
 module Server : sig
   val create_connection_handler
     :  ?config         : Server_connection.Config.t
@@ -15,7 +24,13 @@ end
 
 module Client : sig
   val request
-    :  ([`Active], [< Socket.Address.t]) Socket.t
+    : ?writev:(Async.Fd.t
+               -> Faraday.bigstring Faraday.iovec list
+               -> [ `Ok of int | `Closed ] Async.Deferred.t)
+    -> ?read:(Async.Fd.t
+              -> Buffer.t
+              -> [ `Eof | `Ok of int ] Async.Deferred.t)
+    -> ([`Active], [< Socket.Address.t]) Socket.t
     -> Request.t
     -> error_handler    : Client_connection.error_handler
     -> response_handler : Client_connection.response_handler

--- a/lwt/httpaf_lwt.ml
+++ b/lwt/httpaf_lwt.ml
@@ -65,7 +65,12 @@ module Server = struct
   type request_handler =
     Lwt_unix.file_descr Httpaf.Server_connection.request_handler
 
-  let create_connection_handler ?config ~request_handler ~error_handler =
+  let create_connection_handler
+    ?config
+    ?(writev=Faraday_lwt_unix.writev_of_fd)
+    ?(read=read)
+    ~request_handler
+    ~error_handler =
     fun client_addr socket ->
       let module Server_connection = Httpaf.Server_connection in
       let connection =
@@ -117,7 +122,7 @@ module Server = struct
       in
 
 
-      let writev = Faraday_lwt_unix.writev_of_fd socket in
+      let writev = writev socket in
       let write_loop_exited, notify_write_loop_exited = Lwt.wait () in
 
       let rec write_loop () =

--- a/lwt/httpaf_lwt.mli
+++ b/lwt/httpaf_lwt.mli
@@ -16,6 +16,10 @@ module Server : sig
 
   val create_connection_handler
     :  ?config : Httpaf.Server_connection.Config.t
+    -> ?writev:(Lwt_unix.file_descr
+                -> Faraday.bigstring Faraday.iovec list
+                -> [`Ok of int | `Closed] Lwt.t)
+    -> ?read:(Lwt_unix.file_descr -> Buffer.t -> [ `Eof | `Ok of int ] Lwt.t)
     -> request_handler : (Unix.sockaddr -> request_handler)
     -> error_handler : (Unix.sockaddr -> Httpaf.Server_connection.error_handler)
       -> (Unix.sockaddr -> Lwt_unix.file_descr -> unit Lwt.t)

--- a/lwt/httpaf_lwt.mli
+++ b/lwt/httpaf_lwt.mli
@@ -1,3 +1,12 @@
+module Buffer : sig
+  type t
+
+  val create : int -> t
+
+  val get : t -> f:(Lwt_bytes.t -> off:int -> len:int -> int) -> int
+  val put : t -> f:(Lwt_bytes.t -> off:int -> len:int -> int Lwt.t) -> int Lwt.t
+end
+
 (* The function that results from [create_connection_handler] should be passed
    to [Lwt_io.establish_server_with_client_socket]. For an example, see
    [examples/lwt_echo_server.ml]. *)
@@ -15,7 +24,11 @@ end
 (* For an example, see [examples/lwt_get.ml]. *)
 module Client : sig
   val request
-    :  Lwt_unix.file_descr
+    : ?writev:(Lwt_unix.file_descr
+               -> Faraday.bigstring Faraday.iovec list
+               -> [`Ok of int | `Closed] Lwt.t)
+    -> ?read:(Lwt_unix.file_descr -> Buffer.t -> [ `Eof | `Ok of int ] Lwt.t)
+    -> Lwt_unix.file_descr
     -> Httpaf.Request.t
     -> error_handler : Httpaf.Client_connection.error_handler
     -> response_handler : Httpaf.Client_connection.response_handler


### PR DESCRIPTION
This is a proposal to fix #77. 

The proposed solution is to expose `read` and `writev` in `Client.request` such that users downstream could provide their own functions that read / write encrypted data from / to the underlying socket (e.g. via `ocaml-tls`).

I think this is pretty non-invasive and allows e.g. either `ocaml-ssl` or `ocaml-tls` to be used depending on users' preference.

@seliopou I'm interested to know if you think this is a viable solution. If that's the case, we could do the same in the server module to allow serving via HTTPS.