### PR TITLE
Fix bug where client would hang if response would suddenly EOF

### DIFF
--- a/lib/client_connection.ml
+++ b/lib/client_connection.ml
@@ -132,7 +132,11 @@ module Oneshot = struct
 
   let _next_read_operation t =
     match !(t.state) with
-    | Awaiting_response | Closed -> Reader.next t.reader
+    | Awaiting_response ->
+      if Reader.is_closed t.reader then
+        set_error_and_handle t (`Malformed_response "no response");
+      Reader.next t.reader
+    | Closed -> Reader.next t.reader
     | Received_response(_, response_body) ->
       if not (Body.is_closed response_body)
       then Reader.next t.reader

--- a/lib_test/test_httpaf_client.ml
+++ b/lib_test/test_httpaf_client.ml
@@ -20,7 +20,19 @@ let get  =
 
 let post = []
 
+let malformed_responses_tests = [
+  "single GET, immediate EOF"
+  , `Quick
+  , Simulator.test_client_errors
+      ~request:(Request.create `GET "/")
+      ~request_body_writes:[]
+      ~response_stream:(`Raw [""], `Empty)
+]
+
 let () =
   Alcotest.run "httpaf client tests"
-    [ "GET" , get
-    ; "POST", post ]
+    [
+      "GET" , get
+    ; "POST", post
+    ; "Malformed responses", malformed_responses_tests
+    ]


### PR DESCRIPTION
If the `Client_connection` is awaiting a response but the reader has
already EOFed (and got closed), we need to report that to the error
handler such that downstream (async) code waiting on either and error or
a response body can choose between the two promises.