### PR TITLE
Expose the underlying file descriptors

### DIFF
--- a/async/httpaf_async.ml
+++ b/async/httpaf_async.ml
@@ -96,7 +96,7 @@ module Server = struct
       let writev = Faraday_async.writev_of_fd fd in
       let request_handler = request_handler client_addr in
       let error_handler   = error_handler client_addr in
-      let conn = Server_connection.create ?config ~error_handler request_handler in
+      let conn = Server_connection.create ?config ~error_handler ~fd request_handler in
       let read_complete = Ivar.create () in
       (* XXX(seliopou): Make this configurable *)
       let buffer = Buffer.create 0x1000 in

--- a/lib/httpaf.mli
+++ b/lib/httpaf.mli
@@ -669,6 +669,8 @@ module Reqd : sig
   val response : _ t -> Response.t option
   val response_exn : _ t -> Response.t
 
+  val descriptor : 'handle t -> 'handle
+
   (** Responding
 
       The following functions will initiate a response for the corresponding
@@ -716,6 +718,7 @@ module Server_connection : sig
 
   val create
     :  ?config:Config.t
+    -> fd: 'handle
     -> ?error_handler:error_handler
     -> 'handle request_handler
     -> 'handle t

--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -123,7 +123,7 @@ let default_error_handler ?request:_ error handle =
   Body.close_writer body
 ;;
 
-let create ?(config=Config.default) ?(error_handler=default_error_handler) request_handler =
+let create ?(config=Config.default) ~fd ?(error_handler=default_error_handler) request_handler =
   let
     { Config
     . response_buffer_size
@@ -137,7 +137,7 @@ let create ?(config=Config.default) ?(error_handler=default_error_handler) reque
   let handler request request_body =
     let handle_now = Queue.is_empty request_queue in
     let reqd       =
-      Reqd.create error_handler request request_body writer response_body_buffer in
+      Reqd.create fd error_handler request request_body writer response_body_buffer in
     Queue.push reqd request_queue;
     if handle_now then begin
       request_handler reqd;

--- a/lib_test/simulator.ml
+++ b/lib_test/simulator.ml
@@ -45,7 +45,7 @@ let bigstring_empty = Bigstring.of_string ""
 let test_server ~input ~output ~handler () =
   let reads  = List.(concat (map case_to_strings input)) in
   let writes = List.(concat (map case_to_strings output)) in
-  let conn   = Server_connection.create handler in
+  let conn   = Server_connection.create ~fd:() handler in
   let iwait, owait = ref false, ref false in
   let rec loop conn input reads =
     if !iwait && !owait then

--- a/lib_test/test_httpaf.ml
+++ b/lib_test/test_httpaf.ml
@@ -82,7 +82,7 @@ module IOVec = struct
   ;;
 
   let test_shiftv_raises () =
-    Alcotest.check_raises 
+    Alcotest.check_raises
       "IOVec.shiftv: -1 is a negative number"
       (Failure "IOVec.shiftv: -1 is a negative number")
       (fun () -> ignore (shiftv [] (-1)));
@@ -133,19 +133,19 @@ module Server_connection = struct
   ;;
 
   let test_initial_reader_state () =
-    let t = create default_request_handler in
+    let t = create ~fd:() default_request_handler in
     Alcotest.(check (of_pp Read_operation.pp_hum)) "A new reader wants input"
       `Read (next_read_operation t);
   ;;
 
   let test_reader_is_closed_after_eof () =
-    let t = create default_request_handler in
+    let t = create ~fd:() default_request_handler in
     let c = read_eof t Bigstringaf.empty ~off:0 ~len:0 in
     Alcotest.(check int) "read_eof with no input returns 0" 0 c;
     Alcotest.(check (of_pp Read_operation.pp_hum)) "Shutting down a reader closes it"
       `Close (next_read_operation t);
 
-    let t = create default_request_handler in
+    let t = create ~fd:() default_request_handler in
     let c = read t Bigstringaf.empty ~off:0 ~len:0 in
     Alcotest.(check int) "read with no input returns 0" 0 c;
     let c = read_eof t Bigstringaf.empty ~off:0 ~len:0; in

--- a/lwt/httpaf_lwt.ml
+++ b/lwt/httpaf_lwt.ml
@@ -86,6 +86,7 @@ module Server = struct
       let connection =
         Server_connection.create
           ?config
+          ~fd:socket
           ~error_handler:(error_handler client_addr)
           (request_handler client_addr)
       in


### PR DESCRIPTION
This is a proposal to fix #65. Access to the underlying file descriptors
is (from what I gather) necessary to make use of a websocket connection.
This proposal adds a new function, `Reqd.descriptor`, that returns the
underlying file descriptor.