### PR TITLE
Client bindings: don't shutdown_send immediately

### DIFF
--- a/async/httpaf_async.ml
+++ b/async/httpaf_async.ml
@@ -202,8 +202,6 @@ module Client = struct
       | `Close _ ->
         (* Log.Global.printf "write_close(%d)%!" (Fd.to_int_exn fd); *)
         Ivar.fill write_complete ();
-        if not (Fd.is_closed fd)
-        then Socket.shutdown socket `Send
     in
     let conn_monitor = Monitor.create () in
     Scheduler.within ~monitor:conn_monitor reader_thread;

--- a/lwt/httpaf_lwt.ml
+++ b/lwt/httpaf_lwt.ml
@@ -239,9 +239,6 @@ module Client = struct
 
         | `Close _ ->
           Lwt.wakeup_later notify_write_loop_exited ();
-          if not (Lwt_unix.state socket = Lwt_unix.Closed) then begin
-            shutdown socket Unix.SHUTDOWN_SEND
-          end;
           Lwt.return_unit
       in
 


### PR DESCRIPTION
This is related to #77 and #78, but independent enough to warrant a new
pull request.

When using http/af over HTTPS, the SSL / TLS library needs to keep the
socket open for writing because there might be writes on the upgraded
connection.

This changeset proposes that the http/af `Client` modules don't close
the socket for sending, and instead wait until the request is over to
shutdown the file descriptor.