### PR TITLE
remove-handle-type-param: approach has been abandoned

### DIFF
--- a/async/httpaf_async.mli
+++ b/async/httpaf_async.mli
@@ -6,7 +6,7 @@ open Httpaf
 module Server : sig
   val create_connection_handler
     :  ?config         : Config.t
-    -> request_handler : ('a -> Fd.t Server_connection.request_handler)
+    -> request_handler : ('a -> Server_connection.request_handler)
     -> error_handler   : ('a -> Server_connection.error_handler)
     -> ([< Socket.Address.t] as 'a)
     -> ([`Active], 'a) Socket.t
@@ -15,7 +15,7 @@ end
 
 module Client : sig
   val request
-    :  ?config         : Config.t
+    :  ?config          : Config.t
     -> ([`Active], [< Socket.Address.t]) Socket.t
     -> Request.t
     -> error_handler    : Client_connection.error_handler

--- a/lib/reqd.ml
+++ b/lib/reqd.ml
@@ -34,7 +34,7 @@
 type error =
   [ `Bad_request | `Bad_gateway | `Internal_server_error | `Exn of exn ]
 
-type 'handle response_state =
+type response_state =
   | Waiting   of (unit -> unit) ref
   | Complete  of Response.t
   | Streaming of Response.t * [`write] Body.t
@@ -67,14 +67,14 @@ module Writer = Serialize.Writer
  *  ]}
  *
  * *)
-type 'handle t =
+type t =
   { request                 : Request.t
   ; request_body            : [`read] Body.t
   ; writer                  : Writer.t
   ; response_body_buffer    : Bigstring.t
   ; error_handler           : error_handler
   ; mutable persistent      : bool
-  ; mutable response_state  : 'handle response_state
+  ; mutable response_state  : response_state
   ; mutable error_code      : [`Ok | error ]
   ; mutable wait_for_first_flush : bool
   }

--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -47,7 +47,7 @@ module Reader = Parse.Reader
 module Writer = Serialize.Writer
 
 
-type 'fd request_handler = 'fd Reqd.t -> unit
+type request_handler = Reqd.t -> unit
 
 type error =
   [ `Bad_gateway | `Bad_request | `Internal_server_error | `Exn of exn]
@@ -55,13 +55,13 @@ type error =
 type error_handler =
   ?request:Request.t -> error -> (Headers.t -> [`write] Body.t) -> unit
 
-type 'fd t =
+type t =
   { reader                 : Reader.request
   ; writer                 : Writer.t
   ; response_body_buffer   : Bigstring.t
-  ; request_handler        : 'fd request_handler
+  ; request_handler        : request_handler
   ; error_handler          : error_handler
-  ; request_queue          : 'fd Reqd.t Queue.t
+  ; request_queue          : Reqd.t Queue.t
     (* invariant: If [request_queue] is not empty, then the head of the queue
        has already had [request_handler] called on it. *)
   ; wakeup_writer  : (unit -> unit) list ref

--- a/lwt/httpaf_lwt.ml
+++ b/lwt/httpaf_lwt.ml
@@ -75,9 +75,6 @@ let shutdown socket command =
 module Config = Httpaf.Config
 
 module Server = struct
-  type request_handler =
-    Lwt_unix.file_descr Httpaf.Server_connection.request_handler
-
   let create_connection_handler ?(config=Config.default) ~request_handler ~error_handler =
     fun client_addr socket ->
       let module Server_connection = Httpaf.Server_connection in

--- a/lwt/httpaf_lwt.mli
+++ b/lwt/httpaf_lwt.mli
@@ -1,24 +1,26 @@
+open Httpaf
+
+
 (* The function that results from [create_connection_handler] should be passed
    to [Lwt_io.establish_server_with_client_socket]. For an example, see
    [examples/lwt_echo_server.ml]. *)
 module Server : sig
-  type request_handler =
-    Lwt_unix.file_descr Httpaf.Server_connection.request_handler
-
   val create_connection_handler
-    :  ?config : Httpaf.Config.t
-    -> request_handler : (Unix.sockaddr -> request_handler)
-    -> error_handler : (Unix.sockaddr -> Httpaf.Server_connection.error_handler)
-      -> (Unix.sockaddr -> Lwt_unix.file_descr -> unit Lwt.t)
+    :  ?config         : Config.t
+    -> request_handler : (Unix.sockaddr -> Server_connection.request_handler)
+    -> error_handler   : (Unix.sockaddr -> Server_connection.error_handler)
+    -> Unix.sockaddr
+    -> Lwt_unix.file_descr
+    -> unit Lwt.t
 end
 
 (* For an example, see [examples/lwt_get.ml]. *)
 module Client : sig
   val request
-    :  ?config : Httpaf.Config.t
+    :  ?config          : Httpaf.Config.t
     -> Lwt_unix.file_descr
-    -> Httpaf.Request.t
-    -> error_handler : Httpaf.Client_connection.error_handler
-    -> response_handler : Httpaf.Client_connection.response_handler
-      -> [`write] Httpaf.Body.t
+    -> Request.t
+    -> error_handler    : Client_connection.error_handler
+    -> response_handler : Client_connection.response_handler
+    -> [`write] Httpaf.Body.t
 end


### PR DESCRIPTION
The handle parameter of a server connection was originally intended to support upgrades within the HTTP state machine. This approach was never actually tested for feasiblity. In the mean time a different approach of building support for upgrading into the runtime has been tested for feasiblity, and will be adopted instead.