### PR TITLE
Add `Reqd.respond_with_upgrade` and upgrade handler

### DIFF
--- a/async/httpaf_async.ml
+++ b/async/httpaf_async.ml
@@ -93,18 +93,13 @@ module Server = struct
   let create_connection_handler
     ?(config=Config.default)
     ~request_handler
-    ?upgrade_handler
     ~error_handler =
     fun client_addr socket ->
       let fd     = Socket.fd socket in
       let writev = Faraday_async.writev_of_fd fd in
-      let request_handler = request_handler client_addr in
+      let request_handler = request_handler (client_addr, socket) in
       let error_handler   = error_handler client_addr in
-      let upgrade_handler = match upgrade_handler with
-      | None -> None
-      | Some upgrade_handler -> Some (upgrade_handler client_addr socket)
-      in
-      let conn = Server_connection.create ~config ~error_handler ?upgrade_handler request_handler in
+      let conn = Server_connection.create ~config ~error_handler request_handler in
       let read_complete = Ivar.create () in
       let buffer = Buffer.create config.read_buffer_size in
       let rec reader_thread () =

--- a/async/httpaf_async.mli
+++ b/async/httpaf_async.mli
@@ -7,6 +7,7 @@ module Server : sig
   val create_connection_handler
     :  ?config         : Config.t
     -> request_handler : ('a -> Server_connection.request_handler)
+    -> ?upgrade_handler : ('a -> ([`Active], 'a) Socket.t -> Server_connection.upgrade_handler)
     -> error_handler   : ('a -> Server_connection.error_handler)
     -> ([< Socket.Address.t] as 'a)
     -> ([`Active], 'a) Socket.t

--- a/async/httpaf_async.mli
+++ b/async/httpaf_async.mli
@@ -6,8 +6,7 @@ open Httpaf
 module Server : sig
   val create_connection_handler
     :  ?config         : Config.t
-    -> request_handler : ('a -> Server_connection.request_handler)
-    -> ?upgrade_handler : ('a -> ([`Active], 'a) Socket.t -> Server_connection.upgrade_handler)
+    -> request_handler : ('a * ([`Active], 'a) Socket.t -> Server_connection.request_handler)
     -> error_handler   : ('a -> Server_connection.error_handler)
     -> ([< Socket.Address.t] as 'a)
     -> ([`Active], 'a) Socket.t

--- a/examples/async/async_echo_post.ml
+++ b/examples/async/async_echo_post.ml
@@ -3,7 +3,8 @@ open Async
 
 open Httpaf_async
 
-let request_handler (_ : Socket.Address.Inet.t) = Httpaf_examples.Server.echo_post
+let request_handler (_ : Socket.Address.Inet.t * ([`Active], 'a) Socket.t ) =
+  Httpaf_examples.Server.echo_post
 let error_handler (_ : Socket.Address.Inet.t) = Httpaf_examples.Server.error_handler
 
 let main port max_accepts_per_batch () =

--- a/examples/lwt/lwt_echo_post.ml
+++ b/examples/lwt/lwt_echo_post.ml
@@ -4,7 +4,8 @@ module Arg = Caml.Arg
 
 open Httpaf_lwt_unix
 
-let request_handler (_ : Unix.sockaddr) = Httpaf_examples.Server.echo_post
+let request_handler (_ : Unix.sockaddr * Lwt_unix.file_descr) =
+  Httpaf_examples.Server.echo_post
 let error_handler (_ : Unix.sockaddr) = Httpaf_examples.Server.error_handler
 
 let main port =

--- a/lib/httpaf.mli
+++ b/lib/httpaf.mli
@@ -636,7 +636,7 @@ module Reqd : sig
   val respond_with_string    : t -> Response.t -> string -> unit
   val respond_with_bigstring : t -> Response.t -> Bigstringaf.t -> unit
   val respond_with_streaming : ?flush_headers_immediately:bool -> t -> Response.t -> [`write] Body.t
-  val respond_with_upgrade : t -> Response.t -> [`write] Body.t
+  val respond_with_upgrade : t -> Response.t -> (t -> [`write] Body.t -> unit) -> [`write] Body.t
 
   (** {3 Exception Handling} *)
 
@@ -667,7 +667,6 @@ module Server_connection : sig
     [ `Bad_request | `Bad_gateway | `Internal_server_error | `Exn of exn ]
 
   type request_handler = Reqd.t -> unit
-  type upgrade_handler = Reqd.t -> [`write] Body.t -> unit
 
   type error_handler =
     ?request:Request.t -> error -> (Headers.t -> [`write] Body.t) -> unit
@@ -675,7 +674,6 @@ module Server_connection : sig
   val create
     :  ?config:Config.t
     -> ?error_handler:error_handler
-    -> ?upgrade_handler: upgrade_handler
     -> request_handler
     -> t
   (** [create ?config ?error_handler ~request_handler] creates a connection

--- a/lib/httpaf.mli
+++ b/lib/httpaf.mli
@@ -636,6 +636,7 @@ module Reqd : sig
   val respond_with_string    : t -> Response.t -> string -> unit
   val respond_with_bigstring : t -> Response.t -> Bigstringaf.t -> unit
   val respond_with_streaming : ?flush_headers_immediately:bool -> t -> Response.t -> [`write] Body.t
+  val respond_with_upgrade : t -> Response.t -> [`write] Body.t
 
   (** {3 Exception Handling} *)
 
@@ -666,6 +667,7 @@ module Server_connection : sig
     [ `Bad_request | `Bad_gateway | `Internal_server_error | `Exn of exn ]
 
   type request_handler = Reqd.t -> unit
+  type upgrade_handler = Reqd.t -> [`write] Body.t -> unit
 
   type error_handler =
     ?request:Request.t -> error -> (Headers.t -> [`write] Body.t) -> unit
@@ -673,6 +675,7 @@ module Server_connection : sig
   val create
     :  ?config:Config.t
     -> ?error_handler:error_handler
+    -> ?upgrade_handler: upgrade_handler
     -> request_handler
     -> t
   (** [create ?config ?error_handler ~request_handler] creates a connection

--- a/lib/reqd.ml
+++ b/lib/reqd.ml
@@ -73,23 +73,20 @@ type t =
   ; writer                  : Writer.t
   ; response_body_buffer    : Bigstringaf.t
   ; error_handler           : error_handler
-  ; upgrade_handler         : upgrade_handler
   ; mutable persistent      : bool
   ; mutable response_state  : response_state
   ; mutable error_code      : [`Ok | error ]
   ; mutable wait_for_first_flush : bool
   }
-and upgrade_handler = t -> [`write] Body.t -> unit
 
 let default_waiting = Sys.opaque_identity (fun () -> ())
 
-let create error_handler upgrade_handler request request_body writer response_body_buffer =
+let create error_handler request request_body writer response_body_buffer =
   { request
   ; request_body
   ; writer
   ; response_body_buffer
   ; error_handler
-  ; upgrade_handler
   ; persistent              = Request.persistent_connection request
   ; response_state          = Waiting (ref default_waiting)
   ; error_code              = `Ok
@@ -172,7 +169,7 @@ let respond_with_streaming ?(flush_headers_immediately=false) t response =
     failwith "httpaf.Reqd.respond_with_streaming: invalid state, currently handling error";
   unsafe_respond_with_streaming ~flush_headers_immediately t response
 
-let unsafe_respond_with_upgrade t response =
+let unsafe_respond_with_upgrade t response upgrade_handler =
   match t.response_state with
   | Waiting when_done_waiting ->
     let response_body = Body.create t.response_body_buffer in
@@ -181,7 +178,7 @@ let unsafe_respond_with_upgrade t response =
       t.persistent <- Response.persistent_connection response;
     t.response_state <- Streaming(response, response_body);
     Writer.flush t.writer (fun () ->
-      t.upgrade_handler t response_body;
+      upgrade_handler t response_body;
       done_waiting when_done_waiting);
     response_body
   | Streaming _ ->
@@ -189,10 +186,10 @@ let unsafe_respond_with_upgrade t response =
   | Complete _ ->
     failwith "httpaf.Reqd.respond_with_streaming: response already complete"
 
-let respond_with_upgrade t response =
+let respond_with_upgrade t response upgrade_handler =
   if t.error_code <> `Ok then
     failwith "httpaf.Reqd.respond_with_streaming: invalid state, currently handling error";
-  unsafe_respond_with_upgrade t response
+  unsafe_respond_with_upgrade t response upgrade_handler
 
 let report_error t error =
   t.persistent <- false;

--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -48,6 +48,7 @@ module Writer = Serialize.Writer
 
 
 type request_handler = Reqd.t -> unit
+type upgrade_handler = Reqd.upgrade_handler
 
 type error =
   [ `Bad_gateway | `Bad_request | `Internal_server_error | `Exn of exn]
@@ -60,6 +61,7 @@ type t =
   ; writer                 : Writer.t
   ; response_body_buffer   : Bigstringaf.t
   ; request_handler        : request_handler
+  ; upgrade_handler        : upgrade_handler
   ; error_handler          : error_handler
   ; request_queue          : Reqd.t Queue.t
     (* invariant: If [request_queue] is not empty, then the head of the queue
@@ -114,7 +116,14 @@ let default_error_handler ?request:_ error handle =
   Body.close_writer body
 ;;
 
-let create ?(config=Config.default) ?(error_handler=default_error_handler) request_handler =
+let default_upgrade_handler _reqd _response_body =
+  ()
+
+let create
+  ?(config=Config.default)
+  ?(error_handler=default_error_handler)
+  ?(upgrade_handler=default_upgrade_handler)
+  request_handler =
   let
     { Config
     . response_buffer_size
@@ -128,7 +137,7 @@ let create ?(config=Config.default) ?(error_handler=default_error_handler) reque
   let handler request request_body =
     let handle_now = Queue.is_empty request_queue in
     let reqd       =
-      Reqd.create error_handler request request_body writer response_body_buffer in
+      Reqd.create error_handler upgrade_handler request request_body writer response_body_buffer in
     Queue.push reqd request_queue;
     if handle_now then begin
       request_handler reqd;
@@ -139,6 +148,7 @@ let create ?(config=Config.default) ?(error_handler=default_error_handler) reque
   ; writer
   ; response_body_buffer
   ; request_handler = request_handler
+  ; upgrade_handler = upgrade_handler
   ; error_handler   = error_handler
   ; request_queue
   ; wakeup_writer

--- a/lwt-unix/httpaf_lwt_unix.ml
+++ b/lwt-unix/httpaf_lwt_unix.ml
@@ -109,20 +109,14 @@ module Server = struct
   let create_connection_handler
     ?(config=Config.default)
     ~request_handler
-    ?upgrade_handler
     ~error_handler =
     fun client_addr socket ->
       let module Server_connection = Httpaf.Server_connection in
-      let upgrade_handler = match upgrade_handler with
-      | None -> None
-      | Some upgrade_handler -> Some (upgrade_handler client_addr socket)
-      in
       let connection =
         Server_connection.create
           ~config
           ~error_handler:(error_handler client_addr)
-          ?upgrade_handler
-          (request_handler client_addr)
+          (request_handler (client_addr, socket))
       in
 
       let read_buffer = Buffer.create config.read_buffer_size in

--- a/lwt-unix/httpaf_lwt_unix.ml
+++ b/lwt-unix/httpaf_lwt_unix.ml
@@ -106,13 +106,22 @@ let shutdown socket command =
 module Config = Httpaf.Config
 
 module Server = struct
-  let create_connection_handler ?(config=Config.default) ~request_handler ~error_handler =
+  let create_connection_handler
+    ?(config=Config.default)
+    ~request_handler
+    ?upgrade_handler
+    ~error_handler =
     fun client_addr socket ->
       let module Server_connection = Httpaf.Server_connection in
+      let upgrade_handler = match upgrade_handler with
+      | None -> None
+      | Some upgrade_handler -> Some (upgrade_handler client_addr socket)
+      in
       let connection =
         Server_connection.create
           ~config
           ~error_handler:(error_handler client_addr)
+          ?upgrade_handler
           (request_handler client_addr)
       in
 

--- a/lwt-unix/httpaf_lwt_unix.mli
+++ b/lwt-unix/httpaf_lwt_unix.mli
@@ -41,8 +41,7 @@ open Httpaf
 module Server : sig
   val create_connection_handler
     :  ?config         : Config.t
-    -> request_handler : (Unix.sockaddr -> Server_connection.request_handler)
-    -> ?upgrade_handler : (Unix.sockaddr -> Lwt_unix.file_descr -> Server_connection.upgrade_handler)
+    -> request_handler : (Unix.sockaddr * Lwt_unix.file_descr -> Server_connection.request_handler)
     -> error_handler   : (Unix.sockaddr -> Server_connection.error_handler)
     -> Unix.sockaddr
     -> Lwt_unix.file_descr

--- a/lwt-unix/httpaf_lwt_unix.mli
+++ b/lwt-unix/httpaf_lwt_unix.mli
@@ -42,6 +42,7 @@ module Server : sig
   val create_connection_handler
     :  ?config         : Config.t
     -> request_handler : (Unix.sockaddr -> Server_connection.request_handler)
+    -> ?upgrade_handler : (Unix.sockaddr -> Lwt_unix.file_descr -> Server_connection.upgrade_handler)
     -> error_handler   : (Unix.sockaddr -> Server_connection.error_handler)
     -> Unix.sockaddr
     -> Lwt_unix.file_descr


### PR DESCRIPTION
This diff contains 2 proposals to fix #65:

### d1cd9e6

#### Summary

This diff adds a `Reqd.respond_with_upgrade` function with type `Reqd.t -> Response.t -> [write] Body.t`, along with a (global per connection) upgrade handler to which the Async / Lwt runtimes can pass a file descriptor for applications to handle switching the protocol.

For e.g. the Lwt runtime, the API for upgrading a connection would look like (only relevant bits shown):

```ocaml
let request_handler _address reqd =
  let response = Response.create .... (* Response with "connection: upgrade" headers *)
  in
  Reqd.respond_with_upgrade reqd response
in
let upgrade_handler addr socket _reqd _response_body =
  (* Pass the socket to an external function that communicates over a different protocol *)
in
Httpaf_lwt.Server.create_connection_handler
  ?config:None
  ~request_handler
  ~upgrade_handler
  ~error_handler
```

#### Pros

- The file descriptor is only passed to a function in the explicit case that there is an upgrade of the connection. It is abstracted away in every other case.

#### Cons

- There's a single `upgrade_handler` per connection, which will result in duplication of heuristics if you wanna upgrade to different protocols according to different e.g. routes requested in the application, i.e. `/ws` upgrades to a websocket connection but `/http2` upgrades to a HTTP/2 connection.


### 5ae8cc8

#### Summary

This diff adds a single `Reqd.respond_with_upgrade` function with type `Reqd.t -> Response.t -> (Reqd.t -> [write] Body.t -> unit) -> [write] Body.t` that takes the callback to be invoked whenever the upgrade response has been written to the socket. It also adds a new argument to the `request_handler` function, but **only** in the Async / Lwt runtimes.

In this case, the Lwt API for upgrading a connection would look like (again, only relevant bits shown):

```ocaml
let request_handler addr socket reqd =
  let response = Response.create .... (* Response with "connection: upgrade" headers *)
  in
  Reqd.respond_with_upgrade reqd response (fun reqd responde_body ->
    (* Pass the socket to an external function that communicates over a different protocol *))
in
Httpaf_lwt.Server.create_connection_handler
  ?config:None
  ~request_handler
  ~error_handler
```

#### Pros

- Overall, it is a less invasive change, doesn't add a new handler for _every_ connection
- It solves the locality issue and logic duplication in the case of upgrading a connection to different protocols according to a heuristic. The upgrade handler is now local to every call to `Reqd.respond_with_upgrade`, thus inheriting all the context (and perhaps importantly, lexical scope) necessary to make the upgrade.

#### Cons

- The socket is now passed to every `request_handler` explicitly (only in the I/O runtimes). This disadvantage is arguable due to the fact that one could always hack around this fact and pass it ourselves, i.e.:

```ocaml
(* instead of: *)
Httpaf_lwt.Server.create_connection_handler
  ?config:None
  ~request_handler
  ~error_handler

(* this is possible: *)
  fun socket_addr socket ->
    Httpaf_lwt.Server.create_connection_handler
      ?config:None
      ?upgrade_handler:None
      ~request_handler:(my_request_handler_that_takes socket)
      ~error_handler
      socket_addr socket
```

---

I've tested this downstream with different websocket implementations and either approach works nicely. I'd love to hear your thoughts.

@seliopou Did you have some other approach in mind that I didn't cover?
