### PR TITLE
add examples make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build clean test
+.PHONY: all build clean test examples
 
 build:
 	dune build @install
@@ -7,6 +7,9 @@ all: build
 
 test:
 	dune runtest
+
+examples:
+	dune build --dev @examples
 
 install:
 	dune install

--- a/examples/async/async_echo_post.ml
+++ b/examples/async/async_echo_post.ml
@@ -19,7 +19,7 @@ let error_handler _ ?request:_ error start_response =
 
 let request_handler _ reqd =
   match Reqd.request reqd  with
-  | { Request.meth = `POST; headers } ->
+  | { Request.meth = `POST; headers; _ } ->
     let response =
       let content_type =
         match Headers.get headers "content-type" with

--- a/examples/async/dune
+++ b/examples/async/dune
@@ -3,3 +3,7 @@
  (modules async_echo_post async_get async_post)
  (names async_echo_post async_get async_post)
  (flags (:standard -w -9)))
+
+(alias
+ (name examples)
+ (deps (glob_files *.exe)))

--- a/examples/lwt/dune
+++ b/examples/lwt/dune
@@ -1,3 +1,7 @@
 (executables
  (names lwt_get lwt_post lwt_echo_server)
  (libraries httpaf httpaf-lwt lwt lwt.unix))
+
+(alias
+ (name examples)
+ (deps (glob_files *.exe)))


### PR DESCRIPTION
This adds a new `examples` target to build the dune alias `@examples`
which is defined in the individual `dune` for each example directory.