### PR TITLE
fix examples rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test:
 	dune runtest
 
 examples:
-	dune build --dev @examples
+	dune build @examples
 
 install:
 	dune install


### PR DESCRIPTION
When I changed this from `jbuilder` to `dune`, I didn't try it and
forgot to remove the `--dev` flag.