### PR TITLE
Make "inactive connection" error reporting code path reachable, expose bug

### DIFF
--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -310,6 +310,11 @@ module Reader = struct
     ignore (read_with_more t Bigstringaf.empty ~off:0 ~len:0 Complete : int);
   ;;
 
+  let is_parse_failure t =
+    match t.parse_state with
+    | Fail _ -> true
+    | _ -> false
+
   let next t =
     match t.parse_state with
     | Done ->

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -316,6 +316,6 @@ module Reader = struct
       if t.closed
       then `Close
       else `Read
-    | Fail    _ -> `Close
+    | Fail failure -> `Error failure
     | Partial _ -> `Read
 end

--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -186,6 +186,8 @@ let set_error_and_handle ?request t error =
     t.error_handler ?request error (fun headers ->
       Writer.write_response writer (Response.create ~headers status);
       Body.of_faraday (Writer.faraday writer));
+    (* TODO(anmonteiro): uncomment to fix the failing tests. *)
+    (* wakeup_writer t; *)
   end
 
 let report_exn t exn =

--- a/lib_test/simulator.ml
+++ b/lib_test/simulator.ml
@@ -25,6 +25,7 @@ let body_to_strings = function
 ;;
 
 let case_to_strings = function
+  | `Raw      r, body -> r @ (body_to_strings body)
   | `Request  r, body -> [request_to_string  r] @ (body_to_strings body)
   | `Response r, body -> [response_to_string r] @ (body_to_strings body)
 

--- a/lib_test/test_httpaf_server.ml
+++ b/lib_test/test_httpaf_server.ml
@@ -113,9 +113,21 @@ let streaming_response =
 
 ;;
 
+let malformed_requests_tests = [
+    "single GET, malformed request"
+  , `Quick
+  , Simulator.test_server
+      ~handler: (basic_handler "")
+      ~input:   [ `Raw [ "GET / HTTP/1.1\r\nconnection: close\r\nX-Other-Header : shouldnt_have_space_before_colon\r\n\r\n" ]
+                , `Empty
+                ]
+      ~output:  [(`Response (Response.create `Bad_request)), `Fixed ["400"]]
+]
+
 let () =
   Alcotest.run "httpaf server tests"
     [ "single get"        , single_get
     ; "multiple gets"     , multiple_gets
     ; "streaming response", streaming_response
+    ; "malformed requests", malformed_requests_tests
     ]


### PR DESCRIPTION
This PR adds the test requested in #74 that exposes a bug in the
(previously unreachable) code path that reports and exception in
the case of an inactive connection.

@seliopou I know this is not exactly what we talked about in #74. I believe, however, that the current (now reachable) code might have a bug, as exposed by the failing test that this diff adds. I’ve included a commented call to `wakeup_writer` that makes the test pass when uncommented. 

Do you think this change tests what you wanted? I didn’t find a way to test the code path that #74 changes without propagating the `Fail` state from the parser to `Server_connection`, but maybe you have something else in mind that I'm just not seeing?
