### PR TITLE
report-error-tests: test error reporting for all {,a}sync cases

### DIFF
--- a/lib_test/test_httpaf.ml
+++ b/lib_test/test_httpaf.ml
@@ -262,6 +262,8 @@ module Server_connection = struct
       (String.length get_request_string) c;
     Alcotest.check write_operation "Writer is in a yield state"
       `Yield (next_write_operation t);
+    Alcotest.check read_operation "Reader is in a read state"
+      `Yield (next_read_operation t);
     !continue ();
     Alcotest.check read_operation "Error shuts down the reader"
       `Close (next_read_operation t);
@@ -292,6 +294,8 @@ module Server_connection = struct
       (String.length get_request_string) c;
     Alcotest.check write_operation "Writer is in a yield state"
       `Yield (next_write_operation t);
+    Alcotest.check read_operation "Reader is in a read state"
+      `Yield (next_read_operation t);
     !continue_request ();
     Alcotest.check write_operation "Writer is in a yield state"
       `Yield (next_write_operation t);

--- a/lib_test/test_httpaf.ml
+++ b/lib_test/test_httpaf.ml
@@ -156,6 +156,8 @@ module Server_connection = struct
     ;;
   end
 
+  let write_operation = Alcotest.of_pp Write_operation.pp_hum
+
   let read_string t str =
     let len = String.length str in
     let input = Bigstringaf.of_string str ~off:0 ~len in
@@ -202,7 +204,7 @@ module Server_connection = struct
     let request_string = "/ GET HTTP/1.1\r\n\r\n" in
     let writer_woken_up = ref false in
     let t = create ~error_handler synchronous_raise in
-    Alcotest.(check (of_pp Write_operation.pp_hum)) "Writer is in a yield state"
+    Alcotest.check write_operation "Writer is in a yield state"
       `Yield (next_write_operation t);
     yield_writer t (fun () -> writer_woken_up := true);
     let c = read_string t request_string in
@@ -226,13 +228,13 @@ module Server_connection = struct
         error_handler ?request error start_response)
     in
     let t = create ~error_handler synchronous_raise in
-    Alcotest.(check (of_pp Write_operation.pp_hum)) "Writer is in a yield state"
+    Alcotest.check write_operation "Writer is in a yield state"
       `Yield (next_write_operation t);
     yield_writer t (fun () -> writer_woken_up := true);
     let c = read_string t request_string in
     Alcotest.(check int) "read consumes all input"
       (String.length request_string) c;
-    Alcotest.(check (of_pp Write_operation.pp_hum)) "Writer is in a yield state"
+    Alcotest.check write_operation "Writer is in a yield state"
       `Yield (next_write_operation t);
     !continue ();
     Alcotest.(check (of_pp Read_operation.pp_hum)) "Error shuts down the reader"
@@ -253,13 +255,13 @@ module Server_connection = struct
     let request_string = "/ GET HTTP/1.1\r\n\r\n" in
     let writer_woken_up = ref false in
     let t = create ~error_handler asynchronous_raise in
-    Alcotest.(check (of_pp Write_operation.pp_hum)) "Writer is in a yield state"
+    Alcotest.check write_operation "Writer is in a yield state"
       `Yield (next_write_operation t);
     yield_writer t (fun () -> writer_woken_up := true);
     let c = read_string t request_string in
     Alcotest.(check int) "read consumes all input"
       (String.length request_string) c;
-    Alcotest.(check (of_pp Write_operation.pp_hum)) "Writer is in a yield state"
+    Alcotest.check write_operation "Writer is in a yield state"
       `Yield (next_write_operation t);
     !continue ();
     Alcotest.(check (of_pp Read_operation.pp_hum)) "Error shuts down the reader"
@@ -284,16 +286,16 @@ module Server_connection = struct
     let request_string = "/ GET HTTP/1.1\r\n\r\n" in
     let writer_woken_up = ref false in
     let t = create ~error_handler asynchronous_raise in
-    Alcotest.(check (of_pp Write_operation.pp_hum)) "Writer is in a yield state"
+    Alcotest.check write_operation "Writer is in a yield state"
       `Yield (next_write_operation t);
     yield_writer t (fun () -> writer_woken_up := true);
     let c = read_string t request_string in
     Alcotest.(check int) "read consumes all input"
       (String.length request_string) c;
-    Alcotest.(check (of_pp Write_operation.pp_hum)) "Writer is in a yield state"
+    Alcotest.check write_operation "Writer is in a yield state"
       `Yield (next_write_operation t);
     !continue_request ();
-    Alcotest.(check (of_pp Write_operation.pp_hum)) "Writer is in a yield state"
+    Alcotest.check write_operation "Writer is in a yield state"
       `Yield (next_write_operation t);
     !continue_error ();
     Alcotest.(check (of_pp Read_operation.pp_hum)) "Error shuts down the reader"

--- a/lib_test/test_httpaf.ml
+++ b/lib_test/test_httpaf.ml
@@ -157,6 +157,7 @@ module Server_connection = struct
   end
 
   let write_operation = Alcotest.of_pp Write_operation.pp_hum
+  let read_operation = Alcotest.of_pp Read_operation.pp_hum
   let get_request_string = "GET / HTTP/1.1\r\n\r\n"
 
   let read_string t str =
@@ -181,7 +182,7 @@ module Server_connection = struct
 
   let test_initial_reader_state () =
     let t = create default_request_handler in
-    Alcotest.(check (of_pp Read_operation.pp_hum)) "A new reader wants input"
+    Alcotest.check read_operation "A new reader wants input"
       `Read (next_read_operation t);
   ;;
 
@@ -189,7 +190,7 @@ module Server_connection = struct
     let t = create default_request_handler in
     let c = read_eof t Bigstringaf.empty ~off:0 ~len:0 in
     Alcotest.(check int) "read_eof with no input returns 0" 0 c;
-    Alcotest.(check (of_pp Read_operation.pp_hum)) "Shutting down a reader closes it"
+    Alcotest.check read_operation "Shutting down a reader closes it"
       `Close (next_read_operation t);
 
     let t = create default_request_handler in
@@ -197,7 +198,7 @@ module Server_connection = struct
     Alcotest.(check int) "read with no input returns 0" 0 c;
     let c = read_eof t Bigstringaf.empty ~off:0 ~len:0; in
     Alcotest.(check int) "read_eof with no input returns 0" 0 c;
-    Alcotest.(check (of_pp Read_operation.pp_hum)) "Shutting down a reader closes it"
+    Alcotest.check read_operation "Shutting down a reader closes it"
       `Close (next_read_operation t);
   ;;
 
@@ -210,7 +211,7 @@ module Server_connection = struct
     let c = read_string t get_request_string in
     Alcotest.(check int) "read consumes all input"
       (String.length get_request_string) c;
-    Alcotest.(check (of_pp Read_operation.pp_hum)) "Error shuts down the reader"
+    Alcotest.check read_operation "Error shuts down the reader"
       `Close (next_read_operation t);
     Alcotest.(check bool) "Writer woken up"
       true !writer_woken_up;
@@ -236,7 +237,7 @@ module Server_connection = struct
     Alcotest.check write_operation "Writer is in a yield state"
       `Yield (next_write_operation t);
     !continue ();
-    Alcotest.(check (of_pp Read_operation.pp_hum)) "Error shuts down the reader"
+    Alcotest.check read_operation "Error shuts down the reader"
       `Close (next_read_operation t);
     Alcotest.(check bool) "Writer woken up"
       true !writer_woken_up;
@@ -262,7 +263,7 @@ module Server_connection = struct
     Alcotest.check write_operation "Writer is in a yield state"
       `Yield (next_write_operation t);
     !continue ();
-    Alcotest.(check (of_pp Read_operation.pp_hum)) "Error shuts down the reader"
+    Alcotest.check read_operation "Error shuts down the reader"
       `Close (next_read_operation t);
     Alcotest.(check bool) "Writer woken up"
       true !writer_woken_up;
@@ -295,7 +296,7 @@ module Server_connection = struct
     Alcotest.check write_operation "Writer is in a yield state"
       `Yield (next_write_operation t);
     !continue_error ();
-    Alcotest.(check (of_pp Read_operation.pp_hum)) "Error shuts down the reader"
+    Alcotest.check read_operation "Error shuts down the reader"
       `Close (next_read_operation t);
     Alcotest.(check bool) "Writer woken up"
       true !writer_woken_up;

--- a/lib_test/test_httpaf.ml
+++ b/lib_test/test_httpaf.ml
@@ -157,6 +157,7 @@ module Server_connection = struct
   end
 
   let write_operation = Alcotest.of_pp Write_operation.pp_hum
+  let get_request_string = "GET / HTTP/1.1\r\n\r\n"
 
   let read_string t str =
     let len = String.length str in
@@ -201,15 +202,14 @@ module Server_connection = struct
   ;;
 
   let test_synchronous_error () =
-    let request_string = "/ GET HTTP/1.1\r\n\r\n" in
     let writer_woken_up = ref false in
     let t = create ~error_handler synchronous_raise in
     Alcotest.check write_operation "Writer is in a yield state"
       `Yield (next_write_operation t);
     yield_writer t (fun () -> writer_woken_up := true);
-    let c = read_string t request_string in
+    let c = read_string t get_request_string in
     Alcotest.(check int) "read consumes all input"
-      (String.length request_string) c;
+      (String.length get_request_string) c;
     Alcotest.(check (of_pp Read_operation.pp_hum)) "Error shuts down the reader"
       `Close (next_read_operation t);
     Alcotest.(check bool) "Writer woken up"
@@ -220,7 +220,6 @@ module Server_connection = struct
   ;;
 
   let test_synchronous_error_asynchronous_handling () =
-    let request_string = "/ GET HTTP/1.1\r\n\r\n" in
     let writer_woken_up = ref false in
     let continue = ref (fun () -> ()) in
     let error_handler ?request error start_response =
@@ -231,9 +230,9 @@ module Server_connection = struct
     Alcotest.check write_operation "Writer is in a yield state"
       `Yield (next_write_operation t);
     yield_writer t (fun () -> writer_woken_up := true);
-    let c = read_string t request_string in
+    let c = read_string t get_request_string in
     Alcotest.(check int) "read consumes all input"
-      (String.length request_string) c;
+      (String.length get_request_string) c;
     Alcotest.check write_operation "Writer is in a yield state"
       `Yield (next_write_operation t);
     !continue ();
@@ -252,15 +251,14 @@ module Server_connection = struct
     let asynchronous_raise reqd =
       continue := (fun () -> synchronous_raise reqd)
     in
-    let request_string = "/ GET HTTP/1.1\r\n\r\n" in
     let writer_woken_up = ref false in
     let t = create ~error_handler asynchronous_raise in
     Alcotest.check write_operation "Writer is in a yield state"
       `Yield (next_write_operation t);
     yield_writer t (fun () -> writer_woken_up := true);
-    let c = read_string t request_string in
+    let c = read_string t get_request_string in
     Alcotest.(check int) "read consumes all input"
-      (String.length request_string) c;
+      (String.length get_request_string) c;
     Alcotest.check write_operation "Writer is in a yield state"
       `Yield (next_write_operation t);
     !continue ();
@@ -283,15 +281,14 @@ module Server_connection = struct
       continue_error := (fun () ->
         error_handler ?request error start_response)
     in
-    let request_string = "/ GET HTTP/1.1\r\n\r\n" in
     let writer_woken_up = ref false in
     let t = create ~error_handler asynchronous_raise in
     Alcotest.check write_operation "Writer is in a yield state"
       `Yield (next_write_operation t);
     yield_writer t (fun () -> writer_woken_up := true);
-    let c = read_string t request_string in
+    let c = read_string t get_request_string in
     Alcotest.(check int) "read consumes all input"
-      (String.length request_string) c;
+      (String.length get_request_string) c;
     Alcotest.check write_operation "Writer is in a yield state"
       `Yield (next_write_operation t);
     !continue_request ();

--- a/lib_test/test_httpaf.ml
+++ b/lib_test/test_httpaf.ml
@@ -128,8 +128,52 @@ module Server_connection = struct
     ;;
   end
 
+  module Write_operation = struct
+    type t = [ `Write of Bigstringaf.t IOVec.t list | `Yield | `Close of int ]
+
+    let iovecs_to_string iovecs =
+      let len = IOVec.lengthv iovecs in
+      let bytes = Bytes.create len in
+      let dst_off = ref 0 in
+      List.iter (fun { IOVec.buffer; off = src_off; len } ->
+        Bigstringaf.unsafe_blit_to_bytes buffer ~src_off bytes ~dst_off:!dst_off ~len;
+        dst_off := !dst_off + len)
+      iovecs;
+      Bytes.unsafe_to_string bytes
+    ;;
+
+    let pp_hum fmt t =
+      match t with
+      | `Write iovecs -> Format.fprintf fmt "Write %S" (iovecs_to_string iovecs)
+      | `Yield -> Format.pp_print_string fmt "Yield"
+      | `Close len -> Format.fprintf fmt "Close %i" len
+    ;;
+
+    let to_write_as_string t =
+      match t with
+      | `Write iovecs -> Some (iovecs_to_string iovecs)
+      | `Close _ | `Yield -> None
+    ;;
+  end
+
+  let read_string t str =
+    let len = String.length str in
+    let input = Bigstringaf.of_string str ~off:0 ~len in
+    read t input ~off:0 ~len;
+  ;;
+
   let default_request_handler reqd =
     Reqd.respond_with_string reqd (Response.create `OK) ""
+  ;;
+
+  let synchronous_raise reqd =
+    Reqd.report_exn reqd (Failure "caught this exception")
+  ;;
+
+  let error_handler ?request:_ _error start_response =
+    let resp_body = start_response Headers.empty in
+    Body.write_string resp_body "got an error";
+    Body.close_writer resp_body
   ;;
 
   let test_initial_reader_state () =
@@ -154,9 +198,121 @@ module Server_connection = struct
       `Close (next_read_operation t);
   ;;
 
+  let test_synchronous_error () =
+    let request_string = "/ GET HTTP/1.1\r\n\r\n" in
+    let writer_woken_up = ref false in
+    let t = create ~error_handler synchronous_raise in
+    Alcotest.(check (of_pp Write_operation.pp_hum)) "Writer is in a yield state"
+      `Yield (next_write_operation t);
+    yield_writer t (fun () -> writer_woken_up := true);
+    let c = read_string t request_string in
+    Alcotest.(check int) "read consumes all input"
+      (String.length request_string) c;
+    Alcotest.(check (of_pp Read_operation.pp_hum)) "Error shuts down the reader"
+      `Close (next_read_operation t);
+    Alcotest.(check bool) "Writer woken up"
+      true !writer_woken_up;
+    Alcotest.(check (option string)) "Error response written"
+      (Some "HTTP/1.1 500 Internal Server Error\r\n\r\ngot an error")
+      (next_write_operation t |> Write_operation.to_write_as_string)
+  ;;
+
+  let test_synchronous_error_asynchronous_handling () =
+    let request_string = "/ GET HTTP/1.1\r\n\r\n" in
+    let writer_woken_up = ref false in
+    let continue = ref (fun () -> ()) in
+    let error_handler ?request error start_response =
+      continue := (fun () ->
+        error_handler ?request error start_response)
+    in
+    let t = create ~error_handler synchronous_raise in
+    Alcotest.(check (of_pp Write_operation.pp_hum)) "Writer is in a yield state"
+      `Yield (next_write_operation t);
+    yield_writer t (fun () -> writer_woken_up := true);
+    let c = read_string t request_string in
+    Alcotest.(check int) "read consumes all input"
+      (String.length request_string) c;
+    Alcotest.(check (of_pp Write_operation.pp_hum)) "Writer is in a yield state"
+      `Yield (next_write_operation t);
+    !continue ();
+    Alcotest.(check (of_pp Read_operation.pp_hum)) "Error shuts down the reader"
+      `Close (next_read_operation t);
+    Alcotest.(check bool) "Writer woken up"
+      true !writer_woken_up;
+    Alcotest.(check (option string)) "Error response written"
+      (Some "HTTP/1.1 500 Internal Server Error\r\n\r\ngot an error")
+      (next_write_operation t |> Write_operation.to_write_as_string)
+  ;;
+
+
+  let test_asynchronous_error () =
+    let continue = ref (fun () -> ()) in
+    let asynchronous_raise reqd =
+      continue := (fun () -> synchronous_raise reqd)
+    in
+    let request_string = "/ GET HTTP/1.1\r\n\r\n" in
+    let writer_woken_up = ref false in
+    let t = create ~error_handler asynchronous_raise in
+    Alcotest.(check (of_pp Write_operation.pp_hum)) "Writer is in a yield state"
+      `Yield (next_write_operation t);
+    yield_writer t (fun () -> writer_woken_up := true);
+    let c = read_string t request_string in
+    Alcotest.(check int) "read consumes all input"
+      (String.length request_string) c;
+    Alcotest.(check (of_pp Write_operation.pp_hum)) "Writer is in a yield state"
+      `Yield (next_write_operation t);
+    !continue ();
+    Alcotest.(check (of_pp Read_operation.pp_hum)) "Error shuts down the reader"
+      `Close (next_read_operation t);
+    Alcotest.(check bool) "Writer woken up"
+      true !writer_woken_up;
+    Alcotest.(check (option string)) "Error response written"
+      (Some "HTTP/1.1 500 Internal Server Error\r\n\r\ngot an error")
+      (next_write_operation t |> Write_operation.to_write_as_string)
+  ;;
+
+  let test_asynchronous_error_asynchronous_handling () =
+    let continue_request = ref (fun () -> ()) in
+    let asynchronous_raise reqd =
+      continue_request := (fun () -> synchronous_raise reqd)
+    in
+    let continue_error = ref (fun () -> ()) in
+    let error_handler ?request error start_response =
+      continue_error := (fun () ->
+        error_handler ?request error start_response)
+    in
+    let request_string = "/ GET HTTP/1.1\r\n\r\n" in
+    let writer_woken_up = ref false in
+    let t = create ~error_handler asynchronous_raise in
+    Alcotest.(check (of_pp Write_operation.pp_hum)) "Writer is in a yield state"
+      `Yield (next_write_operation t);
+    yield_writer t (fun () -> writer_woken_up := true);
+    let c = read_string t request_string in
+    Alcotest.(check int) "read consumes all input"
+      (String.length request_string) c;
+    Alcotest.(check (of_pp Write_operation.pp_hum)) "Writer is in a yield state"
+      `Yield (next_write_operation t);
+    !continue_request ();
+    Alcotest.(check (of_pp Write_operation.pp_hum)) "Writer is in a yield state"
+      `Yield (next_write_operation t);
+    !continue_error ();
+    Alcotest.(check (of_pp Read_operation.pp_hum)) "Error shuts down the reader"
+      `Close (next_read_operation t);
+    Alcotest.(check bool) "Writer woken up"
+      true !writer_woken_up;
+    Alcotest.(check (option string)) "Error response written"
+      (Some "HTTP/1.1 500 Internal Server Error\r\n\r\ngot an error")
+      (next_write_operation t |> Write_operation.to_write_as_string)
+  ;;
+
+
   let tests =
     [ "initial reader state"  , `Quick, test_initial_reader_state
     ; "shutdown reader closed", `Quick, test_reader_is_closed_after_eof
+    ; "synchronous error, synchronous handling", `Quick, test_synchronous_error
+    ; "synchronous error, asynchronous handling", `Quick, test_synchronous_error_asynchronous_handling
+    ; "asynchronous error, synchronous handling", `Quick, test_asynchronous_error
+    ; "asynchronous error, asynchronous handling", `Quick, test_asynchronous_error_asynchronous_handling
     ]
 
 end

--- a/lib_test/test_httpaf.ml
+++ b/lib_test/test_httpaf.ml
@@ -234,11 +234,11 @@ module Server_connection = struct
     let c = read_string t get_request_string in
     Alcotest.(check int) "read consumes all input"
       (String.length get_request_string) c;
+    Alcotest.check read_operation "Error shuts down the reader"
+      `Close (next_read_operation t);
     Alcotest.check write_operation "Writer is in a yield state"
       `Yield (next_write_operation t);
     !continue ();
-    Alcotest.check read_operation "Error shuts down the reader"
-      `Close (next_read_operation t);
     Alcotest.(check bool) "Writer woken up"
       true !writer_woken_up;
     Alcotest.(check (option string)) "Error response written"


### PR DESCRIPTION
Demonstrate executions for request handlers that raise synchronously and
asynchronously, as well as handle the error by generating an error
response both syncrhonously and asynchronously.

Asked for in #74.