### PR TITLE
Remove angstrom-async dependency from httpaf-async

### DIFF
--- a/async/dune
+++ b/async/dune
@@ -3,5 +3,5 @@
  (public_name httpaf-async)
  (wrapped false)
  (libraries
-   async core angstrom-async faraday-async httpaf)
+   async core faraday-async httpaf)
  (flags (:standard -safe-string)))

--- a/httpaf-async.opam
+++ b/httpaf-async.opam
@@ -14,7 +14,6 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {build}
-  "angstrom-async" {>= "0.9.0"}
   "faraday-async"
   "async"
   "httpaf" {>= "0.5.0"}


### PR DESCRIPTION
It was unused.

Closes #118.