### PR TITLE
Avoid writing zero chunk in the middle of stream

### DIFF
--- a/lib/body.ml
+++ b/lib/body.ml
@@ -176,7 +176,9 @@ let transfer_to_writer_with_encoding t ~encoding writer =
       t.write_final_if_chunked <- false;
       Serialize.Writer.schedule_fixed writer iovecs
     | `Chunked ->
-      Serialize.Writer.schedule_chunk writer iovecs
+      match iovecs with
+      | [] -> ()
+      | iovecs -> Serialize.Writer.schedule_chunk writer iovecs
     end;
     Serialize.Writer.flush writer (fun () ->
       Faraday.shift faraday lengthv;


### PR DESCRIPTION
Writing empty iovec list as chunk results in chunk with zero length
being emitted to the output stream, which indicates end of stream for
the client.

Fixes #144.