### PR TITLE
Fix bug in Client_connection.report_exn

### DIFF
--- a/lib/client_connection.ml
+++ b/lib/client_connection.ml
@@ -121,8 +121,16 @@ module Oneshot = struct
   ;;
 
   let set_error_and_handle t error =
-    shutdown t;
-    set_error_and_handle_without_shutdown t error;
+    Reader.force_close t.reader;
+    begin match !(t.state) with
+    | Closed -> ()
+    | Awaiting_response ->
+      set_error_and_handle_without_shutdown t error;
+    | Received_response(_, response_body) ->
+      Body.close_reader response_body;
+      Body.execute_read response_body;
+      set_error_and_handle_without_shutdown t error;
+    end
   ;;
 
   let report_exn t exn =


### PR DESCRIPTION
`Client_connection.report_exn` was previously calling `shutdown` which assumed that if the connection was awaiting a response, then the error should always be assumed to be an eof. The code now checks each case and calls the error handler with the provided error after closing the connection.