### PR TITLE
Writer fix

### DIFF
--- a/lib/serialize.ml
+++ b/lib/serialize.ml
@@ -161,7 +161,7 @@ module Writer = struct
 
   let report_result t result =
     match result with
-    | `Closed -> close t
+    | `Closed -> close_and_drain t
     | `Ok len -> shift t.encoder len
 
   let next t =

--- a/lib_test/test_httpaf.ml
+++ b/lib_test/test_httpaf.ml
@@ -569,7 +569,7 @@ module Server_connection = struct
     let t = create default_request_handler in
     read_request   t (Request.create `GET "/");
     write_eof      t;
-    writer_closed  t;
+    writer_closed  t ~unread:19;
   ;;
 
   let tests =


### PR DESCRIPTION
When a write result of `Closed` is reported, the connection continues to report that there are bytes to write. At that point it should just discard any bytes it could write and report that no further writing is possible.

Closes #143.