### PR TITLE
Fix bug in Headers.remove

### DIFF
--- a/lib/headers.ml
+++ b/lib/headers.ml
@@ -102,12 +102,14 @@ let replace t name value =
   with Local -> t
 
 let remove t name =
-  let rec loop s n seen =
+  let rec loop s needle seen =
     match s with
     | [] ->
       if not seen then raise Local else []
-    | (n',_ as nv')::s' ->
-      if CI.equal n n' then loop s' n true else nv'::(loop s' n false)
+    | (name,_ as nv')::s' ->
+      if CI.equal needle name
+      then (print_endline "seen: true"; loop s' needle true )
+      else (print_endline "seen: false"; nv'::(loop s' needle seen))
   in
   try loop t name false
   with Local -> t

--- a/lib_test/test_httpaf.ml
+++ b/lib_test/test_httpaf.ml
@@ -111,6 +111,29 @@ module IOVec = struct
     ; "shiftv raises ", `Quick, test_shiftv_raises ]
 end
 
+module Headers = struct
+  include Headers
+
+  let test_remove () =
+    let check = Alcotest.(check (list (pair string string))) in
+    check "remove leading element"
+      ["c", "d"]
+      (Headers.remove
+        (Headers.of_list ["a", "b"; "c", "d"]) 
+        "a"
+      |> Headers.to_list);
+    check "remove trailing element"
+      ["c", "d"]
+      (Headers.remove
+        (Headers.of_list ["c", "d"; "a", "b"]) 
+        "a"
+      |> Headers.to_list);
+  ;;
+
+  let tests =
+    [ "remove", `Quick, test_remove ]
+end
+
 let maybe_serialize_body f body =
   match body with
   | None -> ()
@@ -793,6 +816,7 @@ let () =
     [ "version"          , Version.tests
     ; "method"           , Method.tests
     ; "iovec"            , IOVec.tests
+    ; "headers"          , Headers.tests
     ; "client connection", Client_connection.tests
     ; "server connection", Server_connection.tests
     ]


### PR DESCRIPTION
A header field wouldn't be removed if it matched the needle and was preceded by non-matching fields in transmission order.