### PR TITLE
dune-not-build: dune can't be a build dependency

### DIFF
--- a/httpaf-async.opam
+++ b/httpaf-async.opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build}
+  "dune"
   "faraday-async"
   "async"
   "httpaf" {>= "0.5.0"}

--- a/httpaf-lwt-unix.opam
+++ b/httpaf-lwt-unix.opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "faraday-lwt-unix"
   "httpaf"
-  "dune" {build}
+  "dune"
   "lwt"
 ]
 synopsis: "Lwt support for http/af"

--- a/httpaf.opam
+++ b/httpaf.opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build}
+  "dune"
   "alcotest" {with-test}
   "bigstringaf" {>= "0.4.0"}
   "angstrom" {>= "0.9.0"}


### PR DESCRIPTION
See ocaml/opam-repository#14266