### PR TITLE
rm-deubg-printfs: remove debug output

### DIFF
--- a/lib/headers.ml
+++ b/lib/headers.ml
@@ -108,8 +108,8 @@ let remove t name =
       if not seen then raise Local else []
     | (name,_ as nv')::s' ->
       if CI.equal needle name
-      then (print_endline "seen: true"; loop s' needle true )
-      else (print_endline "seen: false"; nv'::(loop s' needle seen))
+      then loop s' needle true
+      else nv'::(loop s' needle seen)
   in
   try loop t name false
   with Local -> t


### PR DESCRIPTION
This was left in from #153 