### PR TITLE
Test response parser

### DIFF
--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -125,7 +125,13 @@ let request =
     (headers              <* eol)
 
 let response =
-  let status = take_while P.is_digit >>| Status.of_string in
+  let status =
+    take_while P.is_digit
+    >>= fun str ->
+      if String.length str > 3
+      then fail (Printf.sprintf "status-code too long: %S" str)
+      else return (Status.of_string str)
+  in
   lift4 (fun version status reason headers ->
     Response.create ~reason ~version ~headers status)
     (version              <* char ' ')

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -125,7 +125,7 @@ let request =
     (headers              <* eol)
 
 let response =
-  let status = take_till P.is_space >>| Status.of_string in
+  let status = take_while P.is_digit >>| Status.of_string in
   lift4 (fun version status reason headers ->
     Response.create ~reason ~version ~headers status)
     (version              <* char ' ')

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -128,9 +128,12 @@ let response =
   let status =
     take_while P.is_digit
     >>= fun str ->
-      if String.length str > 3
-      then fail (Printf.sprintf "status-code too long: %S" str)
-      else return (Status.of_string str)
+      if String.length str = 0
+      then fail "status-code empty"
+      else (
+        if String.length str > 3
+        then fail (Printf.sprintf "status-code too long: %S" str)
+        else return (Status.of_string str))
   in
   lift4 (fun version status reason headers ->
     Response.create ~reason ~version ~headers status)
@@ -322,6 +325,6 @@ module Reader = struct
       if t.closed
       then `Close
       else `Read
-    | Fail    _ -> `Close
+    | Fail _ -> `Close
     | Partial _ -> `Read
 end

--- a/lib_test/test_httpaf.ml
+++ b/lib_test/test_httpaf.ml
@@ -234,7 +234,7 @@ module Response = struct
       "HTTP/1.1 200\r\n\r\n";
     check
       "OK response without a status message"
-      ~expect:(Error ": char ' '")
+      ~expect:(Error ": status-code too long: \"999999937377999999999200\"")
       "HTTP/1.1 999999937377999999999200\r\n\r\n";
   ;;
 

--- a/lib_test/test_httpaf.ml
+++ b/lib_test/test_httpaf.ml
@@ -232,7 +232,10 @@ module Response = struct
       "OK response without a status message"
       ~expect:(Error ": char ' '")
       "HTTP/1.1 200\r\n\r\n";
-    ()
+    check
+      "OK response without a status message"
+      ~expect:(Error ": char ' '")
+      "HTTP/1.1 999999937377999999999200\r\n\r\n";
   ;;
 
   let tests =

--- a/lib_test/test_httpaf.ml
+++ b/lib_test/test_httpaf.ml
@@ -234,6 +234,10 @@ module Response = struct
       "HTTP/1.1 200\r\n\r\n";
     check
       "OK response without a status message"
+      ~expect:(Error ": status-code empty")
+      "HTTP/1.1 OK\r\n\r\n";
+    check
+      "OK response without a status message"
       ~expect:(Error ": status-code too long: \"999999937377999999999200\"")
       "HTTP/1.1 999999937377999999999200\r\n\r\n";
   ;;


### PR DESCRIPTION
Add tests for the response parser.

This revealed a bug in the status-code parser that would raise on certain invalid inputs. The fix is also included in this PR.