### PR TITLE
Fix "input shrunk" bug

### DIFF
--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -316,15 +316,17 @@ module Reader = struct
   ;;
 
   let force_close t =
-    ignore (read_with_more t Bigstringaf.empty ~off:0 ~len:0 Complete : int);
+    t.closed <- true;
   ;;
 
   let next t =
-    match t.parse_state with
-    | Done ->
-      if t.closed
-      then `Close
-      else `Read
-    | Fail _ -> `Close
-    | Partial _ -> `Read
+    if t.closed
+    then `Close
+    else (
+      match t.parse_state with
+      | Fail _    -> `Close
+      | Done      -> `Read
+      | Partial _ -> `Read
+    )
+  ;;
 end


### PR DESCRIPTION
When the parser has been fed input but has not hit a commit point so the entire buffer can be consumed, a subsequent `report_exn` call will result in the parser raising with the message "input shrunk".

The fix is to not feed any input to the parser when it is force-closed, but instead make the next call to `next` report close. This will give the caller the opportunity to feed the parser the final bytes available (or to not) before everything shuts down.