### PR TITLE
Optional thunk

### DIFF
--- a/lib/optional_thunk.ml
+++ b/lib/optional_thunk.ml
@@ -1,0 +1,11 @@
+type t = unit -> unit
+
+let none = Sys.opaque_identity (fun () -> ())
+let some f =
+  if f == none
+  then failwith "Optional_thunk: this function is not representable as a some value";
+  f
+
+let is_none t = t == none
+let is_some t = not (is_none t)
+let unchecked_value t = t

--- a/lib/optional_thunk.mli
+++ b/lib/optional_thunk.mli
@@ -1,0 +1,9 @@
+type t
+
+val none : t
+val some : (unit -> unit) -> t
+
+val is_none : t -> bool
+val is_some : t -> bool
+
+val unchecked_value : t -> unit -> unit


### PR DESCRIPTION
Introduce an `Optional_thunk.t` type to replace most of the `Sys.opaque_identities` used throughout the code. This type requires one to check whether it is "none" or "some" before using it as a regular function. The `unchecked_value` function reminds you that you might be performing an unsafe operation.