### PR TITLE
expose parsed headers in the order they were read

### DIFF
--- a/lib/headers.mli
+++ b/lib/headers.mli
@@ -1,0 +1,30 @@
+type t
+
+type name = string
+type value = string
+
+val empty : t
+
+val of_list     : (name * value) list -> t
+val of_rev_list : (name * value) list -> t
+val to_list     : t -> (name * value) list
+val to_rev_list : t -> (name * value) list
+
+val add               : t -> name -> value -> t
+val add_unless_exists : t -> name -> value -> t
+val add_list          : t -> (name * value) list -> t
+val add_multi         : t -> (name * value list) list -> t
+
+val remove  : t -> name -> t
+val replace : t -> name -> value -> t
+
+val mem       : t -> name -> bool
+val get       : t -> name -> value option
+val get_exn   : t -> name -> value
+val get_multi : t -> name -> value list
+
+val iter : f:(name -> value -> unit) -> t -> unit
+val fold : f:(name -> value -> 'a -> 'a) -> init:'a -> t -> 'a
+
+val to_string : t -> string
+val pp_hum : Format.formatter -> t -> unit [@@ocaml.toplevel_printer]

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -114,6 +114,7 @@ let headers =
     >>= function
       | '\r' -> _emp
       | _    -> _rec)
+  >>| Headers.of_list
 
 let request =
   let meth = take_till P.is_space >>| Method.of_string in

--- a/lib_test/test_server_connection.ml
+++ b/lib_test/test_server_connection.ml
@@ -443,7 +443,7 @@ let test_input_shrunk () =
       ; "Connection"     , "close"
       ; "Accept"         , "application/json, text/plain, */*"
       ; "Accept-Language", "en-US,en;q=0.5" ]
-      (Headers.to_rev_list (Reqd.request reqd).headers);
+      (Headers.to_list (Reqd.request reqd).headers);
     Body.close_reader (Reqd.request_body reqd);
     continue_response := (fun () ->
       Reqd.respond_with_string reqd (Response.create `OK) "");


### PR DESCRIPTION
We recursively read off headers from requests (in the case of a server)
and responses (in the case of a client) and construct a list out of
them, but because `Headers.t` is an exposed type, we were able to pass
an ordered list when it should have been reversed. This change adds a
simple mli that matches the interface of `Httpaf.Headers`, which causes
a build error in one location in the parser where we need to reify the
headers from the alist we have. And since we use `lift2 cons`, we have
an ordered list. I also added a test that makes sure they are read in
the correct order, and fixed a test that seemed to be working around the
issue.