### PR TITLE
Fix parse error cases

### DIFF
--- a/examples/async/async_get.ml
+++ b/examples/async/async_get.ml
@@ -4,8 +4,6 @@ open Async
 open Httpaf
 open Httpaf_async
 
-let error_handler _ = assert false
-
 let main port host () =
   let where_to_connect = Tcp.Where_to_connect.of_host_and_port { host; port } in
   Tcp.connect_sock where_to_connect
@@ -15,7 +13,7 @@ let main port host () =
     let headers = Headers.of_list [ "host", host ] in
     let request_body =
       Client.request
-        ~error_handler
+        ~error_handler:Httpaf_examples.Client.error_handler
         ~response_handler
         socket
         (Request.create ~headers `GET "/")

--- a/examples/async/async_post.ml
+++ b/examples/async/async_post.ml
@@ -4,8 +4,6 @@ open Async
 open Httpaf
 open Httpaf_async
 
-let error_handler _ = assert false
-
 let main port host () =
   let where_to_connect = Tcp.Where_to_connect.of_host_and_port { host; port } in
   Tcp.connect_sock where_to_connect
@@ -21,7 +19,7 @@ let main port host () =
     in
     let request_body =
       Client.request
-        ~error_handler
+        ~error_handler:Httpaf_examples.Client.error_handler
         ~response_handler
         socket
         (Request.create ~headers `POST "/")

--- a/examples/lib/httpaf_examples.ml
+++ b/examples/lib/httpaf_examples.ml
@@ -18,7 +18,7 @@ module Client = struct
       | `Invalid_response_body_length _ -> "Invalid body length"
       | `Exn exn -> Format.sprintf "Exn raised: %s" (Exn.to_string exn)
     in
-    Format.eprintf "Error parsing request: %s\n%!" error;
+    Format.eprintf "Error handling response: %s\n%!" error;
   ;;
 
   let print ~on_eof response response_body =

--- a/examples/lib/httpaf_examples.ml
+++ b/examples/lib/httpaf_examples.ml
@@ -9,6 +9,18 @@ let text = "CHAPTER I. Down the Rabbit-Hole  Alice was beginning to get very tir
 let text = Bigstringaf.of_string ~off:0 ~len:(String.length text) text
 
 module Client = struct
+ exception Response_error
+
+  let error_handler error =
+    let error =
+      match error with
+      | `Malformed_response err -> Format.sprintf "Malformed response: %s" err
+      | `Invalid_response_body_length _ -> "Invalid body length"
+      | `Exn exn -> Format.sprintf "Exn raised: %s" (Exn.to_string exn)
+    in
+    Format.eprintf "Error parsing request: %s\n%!" error;
+  ;;
+
   let print ~on_eof response response_body =
     match response with
     | { Response.status = `OK; _ } as response ->

--- a/examples/lwt/lwt_get.ml
+++ b/examples/lwt/lwt_get.ml
@@ -5,8 +5,6 @@ module Arg = Caml.Arg
 open Httpaf
 open Httpaf_lwt_unix
 
-let error_handler _ = assert false
-
 let main port host =
   Lwt_unix.getaddrinfo host (Int.to_string port) [Unix.(AI_FAMILY PF_INET)]
   >>= fun addresses ->
@@ -20,7 +18,7 @@ let main port host =
   let headers = Headers.of_list [ "host", host ] in
   let request_body =
     Client.request
-      ~error_handler
+      ~error_handler:Httpaf_examples.Client.error_handler
       ~response_handler
       socket
       (Request.create ~headers `GET "/")

--- a/examples/lwt/lwt_post.ml
+++ b/examples/lwt/lwt_post.ml
@@ -5,8 +5,6 @@ module Arg = Caml.Arg
 open Httpaf
 open Httpaf_lwt_unix
 
-let error_handler _ = assert false
-
 let main port host =
   Lwt_io.(read stdin)
   >>= fun body ->
@@ -28,7 +26,7 @@ let main port host =
   in
   let request_body =
     Client.request
-      ~error_handler
+      ~error_handler:Httpaf_examples.Client.error_handler
       ~response_handler
       socket
       (Request.create ~headers `POST "/")

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -325,7 +325,7 @@ module Reader = struct
     then `Close
     else (
       match t.parse_state with
-      | Fail _    -> `Close
+      | Fail err  -> `Error err
       | Done      -> `Read
       | Partial _ -> `Read
     )

--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -175,7 +175,8 @@ let set_error_and_handle ?request t error =
     let writer = t.writer in
     t.error_handler ?request error (fun headers ->
       Writer.write_response writer (Response.create ~headers status);
-      Body.reader_of_faraday (Writer.faraday writer));
+      Body.writer_of_faraday (Writer.faraday writer)
+        ~when_ready_to_write:(fun () -> Writer.wakeup writer));
   end
 
 let report_exn t exn =

--- a/lib_test/test_client_connection.ml
+++ b/lib_test/test_client_connection.ml
@@ -2,11 +2,26 @@ open Httpaf
 open Helpers
 open Client_connection
 
+let response_error_pp_hum fmt = function
+  | `Malformed_response str ->
+    Format.fprintf fmt "Malformed_response: %s" str
+  | `Invalid_response_body_length resp ->
+    Format.fprintf fmt "Invalid_response_body_length: %s" (response_to_string resp)
+  | `Exn exn ->
+    Format.fprintf fmt "Exn (%s)" (Printexc.to_string exn)
+;;
+
 module Response = struct
   include Response
 
   let pp = pp_hum
   let equal x y = x = y
+end
+
+module Alcotest = struct
+  include Alcotest
+
+  let response_error = of_pp response_error_pp_hum
 end
 
 let feed_string t str =
@@ -218,10 +233,42 @@ let test_input_shrunk () =
     !error_message
 ;;
 
+let test_failed_response_parse () =
+  let request' = Request.create `GET "/" in
+
+  let test response bytes_read =
+    let error = ref None in
+    let body, t =
+      request
+        request'
+        ~response_handler:(fun _ _ -> assert false)
+        ~error_handler:(fun e -> error := Some e)
+    in
+    Body.close_writer body;
+    write_request t request';
+    writer_closed t;
+    reader_ready t;
+    let len = feed_string t response in
+    Alcotest.(check int) "bytes read" len bytes_read;
+    connection_is_shutdown t;
+    (* XXX(dpatti): The error handler should fire in this case but it does not *)
+    Alcotest.(check (option response_error)) "Response error"
+      None !error;
+  in
+
+  test "HTTP/1.1 200\r\n\r\n" 12;
+
+  let response =
+    Response.create `OK ~headers:(Headers.of_list ["Content-length", "-1"])
+  in
+  test (response_to_string response) 39;
+;;
+
 let tests =
   [ "GET"         , `Quick, test_get
   ; "Response EOF", `Quick, test_response_eof
   ; "Response header order preserved", `Quick, test_response_header_order
   ; "report_exn"  , `Quick, test_report_exn
   ; "input_shrunk", `Quick, test_input_shrunk
+  ; "failed response parse", `Quick, test_failed_response_parse
   ]


### PR DESCRIPTION
Adds a test to demonstrate the broken nature of bad parses or bad requests, and then fixes it by wiring the error case through to the server connection.

@seliopou I know we talked about this briefly and had a few thoughts on what to do. In one situation, we would just forcibly close the connection on a parse error. This makes sense if you just connect to port 80 and write garbage, but it makes less sense if you write a well-formed request with a slight typo. I feel like we had a second idea too, but I forget what it was. I went with the approach of using the existing code, which calls out to the error handler.