### PR TITLE
wake writer when reporting exn through the server

### DIFF
--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -175,7 +175,8 @@ let set_error_and_handle ?request t error =
     let writer = t.writer in
     t.error_handler ?request error (fun headers ->
       Writer.write_response writer (Response.create ~headers status);
-      Body.reader_of_faraday (Writer.faraday writer));
+      Body.writer_of_faraday (Writer.faraday writer)
+        ~when_ready_to_write:(fun () -> Writer.wakeup writer));
   end
 
 let report_exn t exn =


### PR DESCRIPTION
This was a regression from #178: since we incorrectly called this body a
reader, we did not wire up a callback so that it could wake the writer
when closed or flushed. Added a test that fails without the fix.