### PR TITLE
Fix unresponsiveness with multiple requests in a single buffer.

### DIFF
--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -243,11 +243,11 @@ let rec read_with_more t bs ~off ~len more =
     then t.request_handler reqd;
     Reqd.flush_request_body reqd;
   );
-  let off = off + consumed
-  and len = len - consumed in
   (* Keep consuming input as long as progress is made and data is
      available, in case multiple requests were received at once. *)
-  if consumed > 0 && len > 0 then
+  if consumed > 0 && consumed < len then
+    let off = off + consumed
+    and len = len - consumed in
     consumed + read_with_more t bs ~off ~len more
   else
     consumed


### PR DESCRIPTION
Fix issue #189 

If multiple requests were received in a single TCP frame and fit in one buffer, a non-empty read was still forced after the first request, making the server unresponsive to the following one until more data was received.

Only observed with the LWT backend, but seeing the code Ithink Async is affected too.