### PR TITLE
remove unused close-delimited match

### DIFF
--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -245,7 +245,7 @@ module Reader = struct
       | `Fixed 0L  ->
         handler request Body.empty;
         ok
-      | `Fixed _ | `Chunked | `Close_delimited as encoding ->
+      | `Fixed _ | `Chunked as encoding ->
         let request_body = Body.create_reader Bigstringaf.empty in
         handler request request_body;
         body ~encoding request_body *> ok


### PR DESCRIPTION
The fact that this is unused means that there is no representation of a
close-delimited request body. If the content-length header is missing,
it's assumed to be 0 bytes fixed-length.