### PR TITLE
add test for responding mid-read

### DIFF
--- a/lib_test/helpers.ml
+++ b/lib_test/helpers.ml
@@ -61,3 +61,13 @@ end
 
 let write_operation = Alcotest.of_pp Write_operation.pp_hum
 let read_operation = Alcotest.of_pp Read_operation.pp_hum
+
+module Headers = struct
+  include Headers
+
+  let (@) a b = Headers.add_list a (Headers.to_list b)
+
+  let connection_close = Headers.of_list ["connection", "close"]
+  let encoding_chunked = Headers.of_list ["transfer-encoding", "chunked"]
+  let encoding_fixed n = Headers.of_list ["content-length", string_of_int n]
+end

--- a/lib_test/test_client_connection.ml
+++ b/lib_test/test_client_connection.ml
@@ -99,9 +99,7 @@ let test_get () =
   read_response  t response;
 
   (* Single GET, response closes connection *)
-  let response =
-    Response.create `OK ~headers:(Headers.of_list [ "connection", "close" ])
-  in
+  let response = Response.create `OK ~headers:Headers.connection_close in
   let body, t =
     request
       request'
@@ -116,9 +114,7 @@ let test_get () =
   connection_is_shutdown t;
 
   (* Single GET, streaming body *)
-  let response =
-    Response.create `OK ~headers:(Headers.of_list [ "transfer-encoding", "chunked" ])
-  in
+  let response = Response.create `OK ~headers:Headers.encoding_chunked in
   let body, t =
     request
       request'
@@ -257,9 +253,7 @@ let test_failed_response_parse () =
 
   test "HTTP/1.1 200\r\n\r\n" 12 (`Malformed_response ": char ' '");
 
-  let response =
-    Response.create `OK ~headers:(Headers.of_list ["Content-length", "-1"])
-  in
+  let response = Response.create `OK ~headers:(Headers.encoding_fixed (-1)) in
   test (response_to_string response) 39 (`Invalid_response_body_length response);
 ;;
 

--- a/lib_test/test_server_connection.ml
+++ b/lib_test/test_server_connection.ml
@@ -855,20 +855,20 @@ let test_parse_failure_after_checkpoint () =
 ;;
 
 let test_response_finished_before_body_read () =
-  let response = Response.create `OK in
+  let response = Response.create `OK ~headers:(Headers.encoding_fixed 4) in
   let body = ref None in
   let request_handler reqd =
     body := Some (Reqd.request_body reqd);
-    Reqd.respond_with_string reqd response ""
+    Reqd.respond_with_string reqd response "done"
   in
   let t = create request_handler in
   read_request t (Request.create `GET "/" ~headers:(Headers.encoding_fixed 5));
-  write_response t response;
+  write_response t response ~body:"done";
   Body.close_reader (Option.get !body);
   (* Finish the request and send another *)
   read_string t "hello";
   read_request t (Request.create `GET "/");
-  write_response t response;
+  write_response t response ~body:"done";
 ;;
 
 let tests =


### PR DESCRIPTION
This was an untested case that was exposed in another PR. We should be
able to respond before reading the body. Add some test helpers for
headers and replace usages for consistency. I added a currently-unused
`writer_ready` assertion because it's nice when you're trying to probe
the state to debug.