### PR TITLE
massively refactor server connection test framework

### DIFF
--- a/lib_test/helpers.ml
+++ b/lib_test/helpers.ml
@@ -61,3 +61,9 @@ end
 
 let write_operation = Alcotest.of_pp Write_operation.pp_hum
 let read_operation = Alcotest.of_pp Read_operation.pp_hum
+
+let split n str =
+  assert (n <= String.length str);
+  String.sub str 0 n,
+  String.sub str n (String.length str - n)
+;;

--- a/lib_test/helpers.ml
+++ b/lib_test/helpers.ml
@@ -61,9 +61,3 @@ end
 
 let write_operation = Alcotest.of_pp Write_operation.pp_hum
 let read_operation = Alcotest.of_pp Read_operation.pp_hum
-
-let split n str =
-  assert (n <= String.length str);
-  String.sub str 0 n,
-  String.sub str n (String.length str - n)
-;;


### PR DESCRIPTION
This looks like a lot because it is. So here's the thing: when we write
tests like we have been, we just call `next_read_operation` and
`next_write_operation` whenever we want. However, that's not reflective
of reality -- under normal situations, those are called only as a result
of a read/write or when the loop is woken up. So we can easily write a
test that looks right, but never actually happens in the real world.

This approach is different. Abstract away the `Server_connection`, write
a make-shift read/write loop, and memoize the operations when you learn
about them. This way, instead of writing tests that assert against the
*next* operation, they can assert against the *current* operation -- the
one that the loop already discovered.

Additionally, we can make sure that we never send data to the reader or
report some writes to the writer when the runtime is in a different
operation. As it was before, there was nothing stopping us from calling
`read` when the reader was yielded.

There is a slight downside here, which is that we always wake the writer
synchronously and ask for the `next_write_operation`. This means that if
a function flushes twice (as all error handlers do), you have to make
two different assertions. I think this is a pretty small trade-off
though.

I found a few issues with the tests while I was converting things. In
the tests that report exns asynchronously, supposedly the reader is
woken up, but I couldn't find any indicator that it actually happens.
Additionally, one test forgot to `flush` the body, but it worked out
previously because `next_write_operation` transferred the output to the
writer.