### PR TITLE
add proper transfer-encoding parsing

### DIFF
--- a/lib/headers.ml
+++ b/lib/headers.ml
@@ -72,6 +72,8 @@ module CI = struct
     )
 end
 
+let ci_equal = CI.equal
+
 let rec mem t name =
   match t with
   | (name', _)::t' -> CI.equal name name' || mem t' name

--- a/lib/headers.mli
+++ b/lib/headers.mli
@@ -3,6 +3,9 @@ type t
 type name = string
 type value = string
 
+(** Case-insensitive equality for testing header names or values *)
+val ci_equal : string -> string -> bool
+
 val empty : t
 
 val of_list     : (name * value) list -> t

--- a/lib/httpaf.mli
+++ b/lib/httpaf.mli
@@ -528,11 +528,17 @@ module Request : sig
     -> string
     -> t
 
-  val body_length : t -> [
-    | `Fixed of Int64.t
-    | `Chunked
-    | `Error of [`Bad_request]
-  ]
+  module Body_length : sig
+    type t = [
+      | `Fixed of Int64.t
+      | `Chunked
+      | `Error of [`Bad_request]
+    ]
+
+    val pp_hum : Format.formatter -> t -> unit
+  end
+
+  val body_length : t -> Body_length.t
   (** [body_length t] is the length of the message body accompanying [t]. It is
       an error to generate a request with a close-delimited message body.
 
@@ -571,12 +577,18 @@ module Response : sig
       the given parameters. For typical use cases, it's sufficient to provide
       values for [headers] and [status]. *)
 
-  val body_length : ?proxy:bool -> request_method:Method.standard -> t -> [
-    | `Fixed of Int64.t
-    | `Chunked
-    | `Close_delimited
-    | `Error of [ `Bad_gateway | `Internal_server_error ]
-  ]
+  module Body_length : sig
+    type t = [
+      | `Fixed of Int64.t
+      | `Chunked
+      | `Close_delimited
+      | `Error of [ `Bad_gateway | `Internal_server_error ]
+    ]
+
+    val pp_hum : Format.formatter -> t -> unit
+  end
+
+  val body_length : ?proxy:bool -> request_method:Method.standard -> t -> Body_length.t
   (** [body_length ?proxy ~request_method t] is the length of the message body
       accompanying [t] assuming it is a response to a request whose method was
       [request_method]. If the calling code is acting as a proxy, it should

--- a/lib_test/test_request.ml
+++ b/lib_test/test_request.ml
@@ -1,5 +1,8 @@
 open Httpaf
 open Request
+open Helpers
+
+let body_length = Alcotest.of_pp Request.Body_length.pp_hum
 
 let check =
   let alco =
@@ -44,7 +47,58 @@ let test_parse_invalid_errors () =
     "GET / HTTP/1.1\r\nLink : /path/to/some/website\r\n\r\n";
 ;;
 
+let test_body_length () =
+  let check message request ~expect =
+    let actual = Request.body_length request in
+    Alcotest.check body_length message expect actual
+  in
+  let req method_ headers = Request.create method_ ~headers "/" in
+  check
+    "no headers"
+    ~expect:(`Fixed 0L)
+    (req `GET Headers.empty);
+  check
+    "single fixed"
+    ~expect:(`Fixed 10L)
+    (req `GET Headers.(encoding_fixed 10));
+  check
+    "negative fixed"
+    ~expect:(`Error `Bad_request)
+    (req `GET Headers.(encoding_fixed (-10)));
+  check
+    "multiple fixed"
+    ~expect:(`Error `Bad_request)
+    (req `GET Headers.(encoding_fixed 10 @ encoding_fixed 20));
+  check
+    "chunked"
+    ~expect:`Chunked
+    (req `GET Headers.encoding_chunked);
+  check
+    "chunked multiple times"
+    ~expect:`Chunked
+    (req `GET Headers.(encoding_chunked @ encoding_chunked));
+  let encoding_gzip = Headers.of_list ["transfer-encoding", "gzip"] in
+  check
+    "non-chunked transfer-encoding"
+    ~expect:(`Error `Bad_request)
+    (req `GET encoding_gzip);
+  check
+    "chunked after non-chunked"
+    ~expect:`Chunked
+    (req `GET Headers.(encoding_gzip @ encoding_chunked));
+  check
+    "chunked before non-chunked"
+    ~expect:(`Error `Bad_request)
+    (req `GET Headers.(encoding_chunked @ encoding_gzip));
+  check
+    "chunked case-insensitive"
+    ~expect:`Chunked
+    (req `GET Headers.(of_list ["transfer-encoding", "CHUNKED"]));
+;;
+
+
 let tests =
   [ "parse valid"         , `Quick, test_parse_valid
   ; "parse invalid errors", `Quick, test_parse_invalid_errors
+  ; "body length",          `Quick, test_body_length
   ]

--- a/lib_test/test_response.ml
+++ b/lib_test/test_response.ml
@@ -1,5 +1,8 @@
 open Httpaf
 open Response
+open Helpers
+
+let body_length = Alcotest.of_pp Response.Body_length.pp_hum
 
 let check =
   let alco =
@@ -36,7 +39,77 @@ let test_parse_invalid_error () =
     "HTTP/1.1 999999937377999999999200\r\n\r\n";
 ;;
 
+let test_body_length () =
+  let check message request_method response ~expect =
+    let actual = Response.body_length response ~request_method in
+    Alcotest.check body_length message expect actual
+  in
+  let res status headers = Response.create status ~headers in
+  check
+    "requested HEAD"
+    ~expect:(`Fixed 0L)
+    `HEAD (res `OK Headers.empty);
+  check
+    "requested CONNECT"
+    ~expect:(`Close_delimited)
+    `CONNECT (res `OK Headers.empty);
+  check
+    "status: informational"
+    ~expect:(`Fixed 0L)
+    `GET (res `Continue Headers.empty);
+  check
+    "status: no content"
+    ~expect:(`Fixed 0L)
+    `GET (res `No_content Headers.empty);
+  check
+    "status: not modified"
+    ~expect:(`Fixed 0L)
+    `GET (res `Not_modified Headers.empty);
+  check
+    "no header"
+    ~expect:(`Close_delimited)
+    `GET (res `OK Headers.empty);
+  check
+    "single fixed"
+    ~expect:(`Fixed 10L)
+    `GET (res `OK Headers.(encoding_fixed 10));
+  check
+    "negative fixed"
+    ~expect:(`Error `Internal_server_error)
+    `GET (res `OK Headers.(encoding_fixed (-10)));
+  check
+    "multiple fixed"
+    ~expect:(`Error `Internal_server_error)
+    `GET (res `OK Headers.(encoding_fixed 10 @ encoding_fixed 20));
+  check
+    "chunked"
+    ~expect:`Chunked
+    `GET (res `OK Headers.encoding_chunked);
+  check
+    "chunked multiple times"
+    ~expect:`Chunked
+    `GET (res `OK Headers.(encoding_chunked @ encoding_chunked));
+  let encoding_gzip = Headers.of_list ["transfer-encoding", "gzip"] in
+  check
+    "non-chunked transfer-encoding"
+    ~expect:`Close_delimited
+    `GET (res `OK encoding_gzip);
+  check
+    "chunked after non-chunked"
+    ~expect:`Chunked
+    `GET (res `OK Headers.(encoding_gzip @ encoding_chunked));
+  check
+    "chunked before non-chunked"
+    ~expect:`Close_delimited
+    `GET (res `OK Headers.(encoding_chunked @ encoding_gzip));
+  check
+    "chunked case-insensitive"
+    ~expect:`Chunked
+    `GET (res `OK Headers.(of_list ["transfer-encoding", "CHUNKED"]));
+;;
+
 let tests =
   [ "parse valid"        , `Quick, test_parse_valid
   ; "parse invalid error", `Quick, test_parse_invalid_error
+  ; "body length"        , `Quick, test_body_length
   ]


### PR DESCRIPTION
This does two main things to bring it in line with the spec:

1. The values are checked case-insensitive
2. If the header is specified multiple times, later values override
   previous ones

Comprehensive test coverage was added.