### PR TITLE
Realise parse errors immediately

### DIFF
--- a/lib/body.ml
+++ b/lib/body.ml
@@ -115,6 +115,7 @@ let rec do_execute_read t on_eof on_read =
     t.on_eof         <- default_on_eof;
     t.on_read        <- default_on_read;
     on_eof ()
+  (* [Faraday.operation] never returns an empty list of iovecs *)
   | `Writev []       -> assert false
   | `Writev (iovec::_) ->
     t.read_scheduled <- false;

--- a/lib/headers.ml
+++ b/lib/headers.ml
@@ -72,6 +72,8 @@ module CI = struct
     )
 end
 
+let ci_equal = CI.equal
+
 let rec mem t name =
   match t with
   | (name', _)::t' -> CI.equal name name' || mem t' name

--- a/lib/headers.mli
+++ b/lib/headers.mli
@@ -3,6 +3,9 @@ type t
 type name = string
 type value = string
 
+(** Case-insensitive equality for testing header names or values *)
+val ci_equal : string -> string -> bool
+
 val empty : t
 
 val of_list     : (name * value) list -> t

--- a/lib/httpaf.mli
+++ b/lib/httpaf.mli
@@ -528,11 +528,17 @@ module Request : sig
     -> string
     -> t
 
-  val body_length : t -> [
-    | `Fixed of Int64.t
-    | `Chunked
-    | `Error of [`Bad_request]
-  ]
+  module Body_length : sig
+    type t = [
+      | `Fixed of Int64.t
+      | `Chunked
+      | `Error of [`Bad_request]
+    ]
+
+    val pp_hum : Format.formatter -> t -> unit
+  end
+
+  val body_length : t -> Body_length.t
   (** [body_length t] is the length of the message body accompanying [t]. It is
       an error to generate a request with a close-delimited message body.
 
@@ -571,12 +577,18 @@ module Response : sig
       the given parameters. For typical use cases, it's sufficient to provide
       values for [headers] and [status]. *)
 
-  val body_length : ?proxy:bool -> request_method:Method.standard -> t -> [
-    | `Fixed of Int64.t
-    | `Chunked
-    | `Close_delimited
-    | `Error of [ `Bad_gateway | `Internal_server_error ]
-  ]
+  module Body_length : sig
+    type t = [
+      | `Fixed of Int64.t
+      | `Chunked
+      | `Close_delimited
+      | `Error of [ `Bad_gateway | `Internal_server_error ]
+    ]
+
+    val pp_hum : Format.formatter -> t -> unit
+  end
+
+  val body_length : ?proxy:bool -> request_method:Method.standard -> t -> Body_length.t
   (** [body_length ?proxy ~request_method t] is the length of the message body
       accompanying [t] assuming it is a response to a request whose method was
       [request_method]. If the calling code is acting as a proxy, it should

--- a/lib/httpaf.mli
+++ b/lib/httpaf.mli
@@ -459,8 +459,8 @@ module Body : sig
       consume, or when the input channel has been closed and no further bytes
       will be received by the application.
 
-      Once either of these callbacks have been called, they become inactive. 
-      The application is responsible for scheduling subsequent reads, either 
+      Once either of these callbacks have been called, they become inactive.
+      The application is responsible for scheduling subsequent reads, either
       within the [on_read] callback or by some other mechanism. *)
 
   val write_char : [`write] t -> char -> unit
@@ -481,7 +481,7 @@ module Body : sig
   val schedule_bigstring : [`write] t -> ?off:int -> ?len:int -> Bigstringaf.t -> unit
   (** [schedule_bigstring w ?off ?len bs] schedules [bs] to be transmitted at
       the next opportunity without performing a copy. [bs] should not be
-      modified until a subsequent call to {!flush} has successfully 
+      modified until a subsequent call to {!flush} has successfully
       completed. *)
 
   val flush : [`write] t -> (unit -> unit) -> unit
@@ -690,7 +690,7 @@ module Server_connection : sig
       connection to consume. *)
 
   val read_eof : t -> Bigstringaf.t -> off:int -> len:int -> int
-  (** [read_eof t bigstring ~off ~len] reads bytes of input from the provided 
+  (** [read_eof t bigstring ~off ~len] reads bytes of input from the provided
       range of [bigstring] and returns the number of bytes consumed by the
       connection.  {!read_eof} should be called after {!next_read_operation}
       returns a [`Read] and an EOF has been received from the communication
@@ -779,7 +779,7 @@ module Client_connection : sig
       connection to consume. *)
 
   val read_eof : t -> Bigstringaf.t -> off:int -> len:int -> int
-  (** [read_eof t bigstring ~off ~len] reads bytes of input from the provided 
+  (** [read_eof t bigstring ~off ~len] reads bytes of input from the provided
       range of [bigstring] and returns the number of bytes consumed by the
       connection.  {!read_eof} should be called after {!next_read_operation}
       returns a [`Read] and an EOF has been received from the communication

--- a/lib/message.ml
+++ b/lib/message.ml
@@ -38,7 +38,8 @@
 
 let persistent_connection ?(proxy=false) version headers =
   let _ = proxy in
-  (* XXX(seliopou): use proxy argument in the case of HTTP/1.0 *)
+  (* XXX(seliopou): use proxy argument in the case of HTTP/1.0 as per
+     https://tools.ietf.org/html/rfc7230#section-6.3 *)
   match Headers.get headers "connection" with
   | Some "close"      -> false
   | Some "keep-alive" -> Version.(compare version v1_0) >= 0

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -192,7 +192,7 @@ let body ~encoding writer =
       _hex >>= fun size ->
       if size = 0L
       then eol *> finish writer
-      else fixed size ~unexpected:"expected more from body chunk" *> eol *> commit *> p)
+      else fixed size ~unexpected:"expected more from body chunk" *> eol *> p)
   | `Close_delimited ->
     fix (fun p ->
       let _rec = (available >>= fun n -> schedule_size writer n) *> p in

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -263,6 +263,8 @@ module Reader = struct
         handler response Body.empty;
         ok
       | `Fixed _ | `Chunked | `Close_delimited as encoding ->
+        (* We do not trust the length provided in the [`Fixed] case, as the
+           client could DOS easily. *)
         let response_body = Body.create_reader Bigstringaf.empty in
         handler response response_body;
         body ~encoding response_body *> ok

--- a/lib/reqd.ml
+++ b/lib/reqd.ml
@@ -243,15 +243,6 @@ let output_state t : Output_state.t =
   | Waiting -> Waiting
 ;;
 
-let is_complete t =
-  match input_state t with
-  | Ready    -> false
-  | Complete ->
-    (match output_state t with
-     | Waiting | Ready -> false
-     | Complete -> true)
-;;
-
 let flush_request_body t =
   let request_body = request_body t in
   if Body.has_pending_output request_body

--- a/lib/status.ml
+++ b/lib/status.ml
@@ -37,7 +37,7 @@ type informational = [
   | `Switching_protocols
   ]
 
-type successful = [ 
+type successful = [
   | `OK
   | `Created
   | `Accepted
@@ -205,53 +205,53 @@ let to_code = function
 
 let really_unsafe_of_code = function
  (* Informational *)
-  | 100 -> `Continue 
-  | 101 -> `Switching_protocols 
+  | 100 -> `Continue
+  | 101 -> `Switching_protocols
  (* Successful *)
-  | 200 -> `OK 
-  | 201 -> `Created 
-  | 202 -> `Accepted 
-  | 203 -> `Non_authoritative_information 
-  | 204 -> `No_content 
-  | 205 -> `Reset_content 
-  | 206 -> `Partial_content 
+  | 200 -> `OK
+  | 201 -> `Created
+  | 202 -> `Accepted
+  | 203 -> `Non_authoritative_information
+  | 204 -> `No_content
+  | 205 -> `Reset_content
+  | 206 -> `Partial_content
  (* Redirection *)
-  | 300 -> `Multiple_choices 
-  | 301 -> `Moved_permanently 
-  | 302 -> `Found 
-  | 303 -> `See_other 
-  | 304 -> `Not_modified 
-  | 305 -> `Use_proxy 
-  | 307 -> `Temporary_redirect 
+  | 300 -> `Multiple_choices
+  | 301 -> `Moved_permanently
+  | 302 -> `Found
+  | 303 -> `See_other
+  | 304 -> `Not_modified
+  | 305 -> `Use_proxy
+  | 307 -> `Temporary_redirect
  (* Client error *)
-  | 400 -> `Bad_request 
-  | 401 -> `Unauthorized 
-  | 402 -> `Payment_required 
-  | 403 -> `Forbidden 
-  | 404 -> `Not_found 
-  | 405 -> `Method_not_allowed 
+  | 400 -> `Bad_request
+  | 401 -> `Unauthorized
+  | 402 -> `Payment_required
+  | 403 -> `Forbidden
+  | 404 -> `Not_found
+  | 405 -> `Method_not_allowed
   | 406 -> `Not_acceptable
-  | 407 -> `Proxy_authentication_required 
-  | 408 -> `Request_timeout 
-  | 409 -> `Conflict 
-  | 410 -> `Gone 
-  | 411 -> `Length_required 
-  | 412 -> `Precondition_failed 
-  | 413 -> `Payload_too_large 
-  | 414 -> `Uri_too_long 
-  | 415 -> `Unsupported_media_type 
-  | 416 -> `Range_not_satisfiable 
-  | 417 -> `Expectation_failed 
-  | 418 -> `I_m_a_teapot 
-  | 420 -> `Enhance_your_calm 
+  | 407 -> `Proxy_authentication_required
+  | 408 -> `Request_timeout
+  | 409 -> `Conflict
+  | 410 -> `Gone
+  | 411 -> `Length_required
+  | 412 -> `Precondition_failed
+  | 413 -> `Payload_too_large
+  | 414 -> `Uri_too_long
+  | 415 -> `Unsupported_media_type
+  | 416 -> `Range_not_satisfiable
+  | 417 -> `Expectation_failed
+  | 418 -> `I_m_a_teapot
+  | 420 -> `Enhance_your_calm
   | 426 -> `Upgrade_required
  (* Server error *)
-  | 500 -> `Internal_server_error 
-  | 501 -> `Not_implemented 
-  | 502 -> `Bad_gateway 
+  | 500 -> `Internal_server_error
+  | 501 -> `Not_implemented
+  | 502 -> `Bad_gateway
   | 503 -> `Service_unavailable
-  | 504 -> `Gateway_timeout 
-  | 505 -> `Http_version_not_supported 
+  | 504 -> `Gateway_timeout
+  | 505 -> `Http_version_not_supported
   | c   -> `Code c
 
 let unsafe_of_code c =

--- a/lib_test/test_client_connection.ml
+++ b/lib_test/test_client_connection.ml
@@ -148,7 +148,7 @@ let test_response_eof () =
   Alcotest.(check int) "read_eof with no input returns 0" 0 c;
   connection_is_shutdown t;
   Alcotest.(check (option string)) "unexpected eof"
-    (Some "unexpected eof")
+    (Some ": not enough input")
     !error_message
 ;;
 

--- a/lib_test/test_client_connection.ml
+++ b/lib_test/test_client_connection.ml
@@ -246,9 +246,12 @@ let test_failed_response_parse () =
     reader_ready t;
     let len = feed_string t response in
     Alcotest.(check int) "bytes read" len bytes_read;
-    connection_is_shutdown t;
+    (* A previous version of httpaf required one to call [next_read_operation] in order to
+       get the error handler to be called. This test now demonstrates that this is no
+       longer the case: [!error] is already [Some _]. *)
     Alcotest.(check (option response_error)) "Response error"
       (Some expected_error) !error;
+    connection_is_shutdown t;
   in
 
   test "HTTP/1.1 200\r\n\r\n" 12 (`Malformed_response ": char ' '");

--- a/lib_test/test_request.ml
+++ b/lib_test/test_request.ml
@@ -1,5 +1,8 @@
 open Httpaf
 open Request
+open Helpers
+
+let body_length = Alcotest.of_pp Request.Body_length.pp_hum
 
 let check =
   let alco =
@@ -44,7 +47,58 @@ let test_parse_invalid_errors () =
     "GET / HTTP/1.1\r\nLink : /path/to/some/website\r\n\r\n";
 ;;
 
+let test_body_length () =
+  let check message request ~expect =
+    let actual = Request.body_length request in
+    Alcotest.check body_length message expect actual
+  in
+  let req method_ headers = Request.create method_ ~headers "/" in
+  check
+    "no headers"
+    ~expect:(`Fixed 0L)
+    (req `GET Headers.empty);
+  check
+    "single fixed"
+    ~expect:(`Fixed 10L)
+    (req `GET Headers.(encoding_fixed 10));
+  check
+    "negative fixed"
+    ~expect:(`Error `Bad_request)
+    (req `GET Headers.(encoding_fixed (-10)));
+  check
+    "multiple fixed"
+    ~expect:(`Error `Bad_request)
+    (req `GET Headers.(encoding_fixed 10 @ encoding_fixed 20));
+  check
+    "chunked"
+    ~expect:`Chunked
+    (req `GET Headers.encoding_chunked);
+  check
+    "chunked multiple times"
+    ~expect:`Chunked
+    (req `GET Headers.(encoding_chunked @ encoding_chunked));
+  let encoding_gzip = Headers.of_list ["transfer-encoding", "gzip"] in
+  check
+    "non-chunked transfer-encoding"
+    ~expect:(`Error `Bad_request)
+    (req `GET encoding_gzip);
+  check
+    "chunked after non-chunked"
+    ~expect:`Chunked
+    (req `GET Headers.(encoding_gzip @ encoding_chunked));
+  check
+    "chunked before non-chunked"
+    ~expect:(`Error `Bad_request)
+    (req `GET Headers.(encoding_chunked @ encoding_gzip));
+  check
+    "chunked case-insensitive"
+    ~expect:`Chunked
+    (req `GET Headers.(of_list ["transfer-encoding", "CHUNKED"]));
+;;
+
+
 let tests =
   [ "parse valid"         , `Quick, test_parse_valid
   ; "parse invalid errors", `Quick, test_parse_invalid_errors
+  ; "body length",          `Quick, test_body_length
   ]

--- a/lib_test/test_response.ml
+++ b/lib_test/test_response.ml
@@ -1,5 +1,8 @@
 open Httpaf
 open Response
+open Helpers
+
+let body_length = Alcotest.of_pp Response.Body_length.pp_hum
 
 let check =
   let alco =
@@ -36,7 +39,77 @@ let test_parse_invalid_error () =
     "HTTP/1.1 999999937377999999999200\r\n\r\n";
 ;;
 
+let test_body_length () =
+  let check message request_method response ~expect =
+    let actual = Response.body_length response ~request_method in
+    Alcotest.check body_length message expect actual
+  in
+  let res status headers = Response.create status ~headers in
+  check
+    "requested HEAD"
+    ~expect:(`Fixed 0L)
+    `HEAD (res `OK Headers.empty);
+  check
+    "requested CONNECT"
+    ~expect:(`Close_delimited)
+    `CONNECT (res `OK Headers.empty);
+  check
+    "status: informational"
+    ~expect:(`Fixed 0L)
+    `GET (res `Continue Headers.empty);
+  check
+    "status: no content"
+    ~expect:(`Fixed 0L)
+    `GET (res `No_content Headers.empty);
+  check
+    "status: not modified"
+    ~expect:(`Fixed 0L)
+    `GET (res `Not_modified Headers.empty);
+  check
+    "no header"
+    ~expect:(`Close_delimited)
+    `GET (res `OK Headers.empty);
+  check
+    "single fixed"
+    ~expect:(`Fixed 10L)
+    `GET (res `OK Headers.(encoding_fixed 10));
+  check
+    "negative fixed"
+    ~expect:(`Error `Internal_server_error)
+    `GET (res `OK Headers.(encoding_fixed (-10)));
+  check
+    "multiple fixed"
+    ~expect:(`Error `Internal_server_error)
+    `GET (res `OK Headers.(encoding_fixed 10 @ encoding_fixed 20));
+  check
+    "chunked"
+    ~expect:`Chunked
+    `GET (res `OK Headers.encoding_chunked);
+  check
+    "chunked multiple times"
+    ~expect:`Chunked
+    `GET (res `OK Headers.(encoding_chunked @ encoding_chunked));
+  let encoding_gzip = Headers.of_list ["transfer-encoding", "gzip"] in
+  check
+    "non-chunked transfer-encoding"
+    ~expect:`Close_delimited
+    `GET (res `OK encoding_gzip);
+  check
+    "chunked after non-chunked"
+    ~expect:`Chunked
+    `GET (res `OK Headers.(encoding_gzip @ encoding_chunked));
+  check
+    "chunked before non-chunked"
+    ~expect:`Close_delimited
+    `GET (res `OK Headers.(encoding_chunked @ encoding_gzip));
+  check
+    "chunked case-insensitive"
+    ~expect:`Chunked
+    `GET (res `OK Headers.(of_list ["transfer-encoding", "CHUNKED"]));
+;;
+
 let tests =
   [ "parse valid"        , `Quick, test_parse_valid
   ; "parse invalid error", `Quick, test_parse_invalid_error
+  ; "body length"        , `Quick, test_body_length
   ]

--- a/lib_test/test_server_connection.ml
+++ b/lib_test/test_server_connection.ml
@@ -836,6 +836,20 @@ let test_multiple_async_requests_in_single_read () =
   reader_ready t;
 ;;
 
+let test_multiple_requests_in_single_read_with_close () =
+  let response = Response.create `OK ~headers:Headers.connection_close in
+  let t =
+    create (fun reqd -> Reqd.respond_with_string reqd response "")
+  in
+  let reqs =
+    request_to_string (Request.create `GET "/") ^
+    request_to_string (Request.create `GET "/")
+  in
+  read_string t reqs;
+  write_response t response;
+  connection_is_shutdown t;
+;;
+
 let test_parse_failure_after_checkpoint () =
   let error_queue = ref None in
   let error_handler ?request:_ error _start_response =
@@ -905,6 +919,7 @@ let tests =
   ; "bad request", `Quick, test_bad_request
   ; "multiple requests in single read", `Quick, test_multiple_requests_in_single_read
   ; "multiple async requests in single read", `Quick, test_multiple_async_requests_in_single_read
+  ; "multiple requests with connection close", `Quick, test_multiple_requests_in_single_read_with_close
   ; "parse failure after checkpoint", `Quick, test_parse_failure_after_checkpoint
   ; "response finished before body read", `Quick, test_response_finished_before_body_read
   ]


### PR DESCRIPTION
Calling `{Server,Client}_connection.read{,_eof}` can leave the parser in an error state. At the moment, this does not call the error handler until the next time that `next_read_operation` is called. This is a bit error prone -- for instance, if this is a call to `read_eof`, the runtime might not naturally want to call `next_read_operation` afterwards.

This is demonstrated via a change to test_client_connection.ml. Note that it also changes one of the error messages for another test -- this is due to the error handler now being called before the unexpected_eof check at client_connection.ml:193.

Unfortunately it's hard to demonstrate the use of this in server_connection.ml, as the test runtime always calls `next_read_operation` after every read.