### PR TITLE
Body.schedule_read should call on_read immediately if data is available

### DIFF
--- a/lib/body.ml
+++ b/lib/body.ml
@@ -136,7 +136,8 @@ let schedule_read t ~on_eof ~on_read =
   else begin
     t.read_scheduled <- true;
     t.on_eof         <- on_eof;
-    t.on_read        <- on_read
+    t.on_read        <- on_read;
+    do_execute_read t on_eof on_read;
   end
 
 let has_pending_output t =

--- a/lib/body.ml
+++ b/lib/body.ml
@@ -131,14 +131,12 @@ and execute_read t =
 let schedule_read t ~on_eof ~on_read =
   if t.read_scheduled
   then failwith "Body.schedule_read: reader already scheduled";
-  if is_closed t
-  then do_execute_read t on_eof on_read
-  else begin
+  if not (is_closed t) then begin
     t.read_scheduled <- true;
     t.on_eof         <- on_eof;
     t.on_read        <- on_read;
-    do_execute_read t on_eof on_read;
-  end
+  end;
+  do_execute_read t on_eof on_read
 
 let has_pending_output t =
   (* Force another write poll to make sure that the final chunk is emitted for

--- a/lib_test/test_client_connection.ml
+++ b/lib_test/test_client_connection.ml
@@ -44,6 +44,11 @@ let reader_ready t =
     `Read (next_read_operation t :> [`Close | `Read | `Yield]);
 ;;
 
+let reader_closed t =
+  Alcotest.check read_operation "Reader is closed"
+    `Close (next_read_operation t :> [`Close | `Read | `Yield]);
+;;
+
 let write_string ?(msg="output written") t str =
   let len = String.length str in
   Alcotest.(check (option string)) msg
@@ -277,9 +282,9 @@ let test_failed_response_parse () =
   test (response_to_string response) 39 (`Invalid_response_body_length response);
 ;;
 
-let test_body_schedule_read_with_data_available () =
+let test_schedule_read_with_data_available () =
   let request' = Request.create `GET "/" in
-  let response = Response.create `OK ~headers:(Headers.encoding_fixed 11) in
+  let response = Response.create `OK ~headers:(Headers.encoding_fixed 6) in
 
   let body = ref None in
   let response_handler response' body' =
@@ -290,23 +295,36 @@ let test_body_schedule_read_with_data_available () =
     request request' ~response_handler ~error_handler:no_error_handler
   in
   Body.close_writer req_body;
-  write_request  t request';
-  writer_closed  t;
-  read_response  t response;
+  write_request t request';
+  writer_closed t;
+  read_response t response;
+
+  let body = Option.get !body in
+  let schedule_read expected =
+    let did_read = ref false in
+    Body.schedule_read body
+      ~on_read:(fun buf ~off ~len ->
+        let actual = Bigstringaf.substring buf ~off ~len in
+        did_read := true;
+        Alcotest.(check string) "Body" expected actual)
+      ~on_eof:(fun () -> assert false);
+    Alcotest.(check bool) "on_read called" true !did_read;
+  in
 
   (* We get some data on the connection, but not the full response yet. *)
   read_string t "Hello";
 
   (* Schedule a read when there is already data available. on_read should be called
      straight away, as who knows how long it'll be before more data arrives. *)
-  let body = Option.get !body in
-  let on_read_called = ref false in
+  schedule_read "Hello";
+  read_string t "!";
+  schedule_read "!";
+  let did_eof = ref false in
   Body.schedule_read body
-    ~on_read:(fun buf ~off ~len ->
-      on_read_called := true;
-      Alcotest.(check string) "Body" (Bigstringaf.substring buf ~off ~len) "Hello")
-    ~on_eof:(fun () -> assert false);
-  Alcotest.(check bool) "on_read called" !on_read_called true
+    ~on_read:(fun _ ~off:_ ~len:_ -> Alcotest.fail "Expected eof")
+    ~on_eof:(fun () -> did_eof := true);
+  Alcotest.(check bool) "on_eof called" true !did_eof;
+  reader_closed t;
 ;;
 
 let tests =
@@ -317,6 +335,5 @@ let tests =
   ; "report_exn"  , `Quick, test_report_exn
   ; "input_shrunk", `Quick, test_input_shrunk
   ; "failed response parse", `Quick, test_failed_response_parse
-  ; "Body.schedule_read with data available", `Quick,
-    test_body_schedule_read_with_data_available
+  ; "schedule read with data available", `Quick, test_schedule_read_with_data_available
   ]

--- a/lib_test/test_server_connection.ml
+++ b/lib_test/test_server_connection.ml
@@ -943,30 +943,42 @@ let test_shutdown_during_asynchronous_request () =
   writer_closed t
 ;;
 
-let test_body_schedule_read_with_data_available () =
-  let response = Response.create `OK ~headers:(Headers.encoding_fixed 4) in
+let test_schedule_read_with_data_available () =
+  let response = Response.create `OK in
   let body = ref None in
+  let continue = ref (fun () -> ()) in
   let request_handler reqd =
     body := Some (Reqd.request_body reqd);
-    Reqd.respond_with_string reqd response "done"
+    continue := (fun () ->
+      Reqd.respond_with_string reqd response "")
   in
   let t = create request_handler in
-  read_request t (Request.create `GET "/" ~headers:(Headers.encoding_fixed 11));
-  write_response t response ~body:"done";
+  read_request t (Request.create `GET "/" ~headers:(Headers.encoding_fixed 6));
+
+  let body = Option.get !body in
+  let schedule_read expected =
+    let did_read = ref false in
+    Body.schedule_read body
+      ~on_read:(fun buf ~off ~len ->
+        let actual = Bigstringaf.substring buf ~off ~len in
+        did_read := true;
+        Alcotest.(check string) "Body" expected actual)
+      ~on_eof:(fun () -> assert false);
+    Alcotest.(check bool) "on_read called" true !did_read;
+  in
 
   (* We get some data on the connection, but not the full response yet. *)
   read_string t "Hello";
-
-  (* Schedule a read when there is already data available. on_read should be called
-     straight away, as who knows how long it'll be before more data arrives. *)
-  let body = Option.get !body in
-  let on_read_called = ref false in
+  (* Schedule a read when there is already data available. on_read should be
+     called synchronously *)
+  schedule_read "Hello";
+  read_string t "!";
+  schedule_read "!";
+  (* Also works with eof *)
   Body.schedule_read body
-    ~on_read:(fun buf ~off ~len ->
-      on_read_called := true;
-      Alcotest.(check string) "Body" (Bigstringaf.substring buf ~off ~len) "Hello")
-    ~on_eof:(fun () -> assert false);
-  Alcotest.(check bool) "on_read called" !on_read_called true
+    ~on_read:(fun _ ~off:_ ~len:_ -> Alcotest.fail "Expected eof")
+    ~on_eof:(fun () -> !continue ());
+  write_response t response;
 ;;
 
 let tests =
@@ -1000,5 +1012,5 @@ let tests =
   ; "response finished before body read", `Quick, test_response_finished_before_body_read
   ; "shutdown in request handler", `Quick, test_shutdown_in_request_handler
   ; "shutdown during asynchronous request", `Quick, test_shutdown_during_asynchronous_request
-  ; "Body.schedule_read with data available", `Quick, test_body_schedule_read_with_data_available
+  ; "schedule read with data available", `Quick, test_schedule_read_with_data_available
   ]


### PR DESCRIPTION
If one calls `on_read` when data is immediately available, we should immediately schedule a read. For instance, consider the following sequence of events:

1. Data arrives on a connection
2. `Body.schedule_read` is called
3. A long time passes
4. More data arrives on the connection

In this case, the `on_read` function passed to `Body.schedule_read` was not being called until step (4).

This PR fixes the issue and presents a test using both `Client_connection` and `Server_connection`. 