### PR TITLE
Fix parse error at EOF

### DIFF
--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -304,6 +304,7 @@ module Reader = struct
     let consumed =
       match t.parse_state with
       | Fail _ -> 0
+      (* Don't feed empty input when we're at a request boundary *)
       | Done when len = 0 -> 0
       | Done   ->
         start t (AU.parse t.parser);

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -313,8 +313,8 @@ module Reader = struct
         transition t (continue bs more ~off ~len)
     in
     begin match more with
-    | Complete -> t.closed <- true;
-    | Incomplete -> ()
+    | Complete when consumed = len -> t.closed <- true;
+    | Complete | Incomplete -> ()
     end;
     consumed;
   ;;


### PR DESCRIPTION
Currently, if there is a parse error after `read_eof`, the runtime has no
chance to discover it. The error is not surfaced immediately, and if
the runtime calls `next_read_operation`, it just gets `` `Close``.
This is because `Reader.next` first checks to see if it is closed, and
if so, always returns `` `Close``.

This feature fixes this by inverting the logic in that function.

Unfortunately this leads to another problem: the parser effectively
expects an unending stream of requests, because after finishing
parsing one request it immediately expects the next one. This means
that read_eof is guaranteed to lead to a parse error. Thankfully this
is easily fixed by treating an empty input as a valid as well.