### PR TITLE
Flush response before shutting down

### DIFF
--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -144,6 +144,7 @@ let shutdown_reader t =
   else wakeup_reader t
 
 let shutdown_writer t =
+  if is_active t then Reqd.flush_response_body (current_reqd_exn t);
   Writer.close t.writer;
   if is_active t
   then Reqd.close_request_body (current_reqd_exn t)

--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -147,6 +147,9 @@ let shutdown_reader t =
 let shutdown_writer t =
   if is_active t then (
     let reqd = current_reqd_exn t in
+    (* XXX(dpatti): I'm not sure I understand why we close the *request* body
+       here. Maybe we can write a test such that removing this line causes it to
+       fail? *)
     Reqd.close_request_body reqd;
     Reqd.flush_response_body reqd);
   Writer.close t.writer;


### PR DESCRIPTION
`Server_connection.shutdown` immediately calls `Writer.close`. But we should flush the response body in case the user has written something to the body and not yet flushed the body.

You could argue this is not needed because the user should be careful to flush their body before shutting down. In the structure of my program, this is hard to ensure. I expose a function to shut down the HTTP server, which calls Server_connection.shutdown on all live connections. It's hard for that function to know what the current state of all of the response handlers are.