### PR TITLE
add `make watch` for development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ test:
 examples:
 	dune build @examples
 
+watch:
+	dune build {httpaf,httpaf-async,httpaf-lwt-unix}.install @runtest --watch
+
 install:
 	dune install
 


### PR DESCRIPTION
I use this for fast feedback while developing and thought it would be
good to put in the `Makefile`. I would have built the examples and
benchmarks too, but all the linking makes the whole iteration take an
order of magnitude longer. Maybe there's some dune option I'm missing
here to let us build but not link.