### PR TITLE
Surface write failures through [flush]

### DIFF
--- a/examples/async/async_post.ml
+++ b/examples/async/async_post.ml
@@ -28,7 +28,7 @@ let main port host () =
     don't_wait_for (
       Reader.read_one_chunk_at_a_time stdin ~handle_chunk:(fun bs ~pos:off ~len ->
         Body.Writer.write_bigstring request_body bs ~off ~len;
-        Body.Writer.flush request_body (fun () -> ());
+        Body.Writer.flush request_body Fn.ignore;
         return (`Consumed(len, `Need_unknown)))
       >>| function
         | `Eof_with_unconsumed_data s -> Body.Writer.write_string request_body s;

--- a/lib/body.ml
+++ b/lib/body.ml
@@ -155,8 +155,8 @@ module Writer = struct
       Faraday.flush_with_reason t.faraday (fun reason ->
         let result =
           match reason with
-          | `Nothing_pending | `Shift -> `Written
-          | `Drain -> `Closed
+          | Nothing_pending | Shift -> `Written
+          | Drain -> `Closed
         in
         kontinue result);
       ready_to_write t

--- a/lib/client_connection.ml
+++ b/lib/client_connection.ml
@@ -71,8 +71,8 @@ module Oneshot = struct
         | `Error `Bad_request ->
           failwith "Httpaf.Client_connection.request: invalid body length"
       in
-      Body.Writer.create (Bigstringaf.create config.request_body_buffer_size)
-        ~encoding ~when_ready_to_write:(fun () -> Writer.wakeup writer)
+      Body.Writer.create (Bigstringaf.create config.request_body_buffer_size) writer
+        ~encoding
     in
     let t =
       { request
@@ -89,7 +89,7 @@ module Oneshot = struct
 
   let flush_request_body t =
     if Body.Writer.has_pending_output t.request_body
-    then Body.Writer.transfer_to_writer t.request_body t.writer
+    then Body.Writer.transfer_to_writer t.request_body
   ;;
 
   let set_error_and_handle_without_shutdown t error =

--- a/lib/httpaf.mli
+++ b/lib/httpaf.mli
@@ -498,9 +498,10 @@ module Body : sig
         completed. *)
 
     val flush : t -> ([ `Written | `Closed ] -> unit) -> unit
-    (** [flush t f] makes all bytes in [t] available for writing to the awaiting
-        output channel. Once those bytes have reached that output channel, [f]
-        will be called.
+    (** [flush t f] makes all bytes in [t] available for writing to the awaiting output
+        channel. Once those bytes have reached that output channel, [f `Written] will be
+        called. If instead, the output channel is closed before all of those bytes are
+        successfully written, [f `Closed] will be called.
 
         The type of the output channel is runtime-dependent, as are guarantees
         about whether those packets have been queued for delivery or have
@@ -512,8 +513,9 @@ module Body : sig
         to the output channel. *)
 
     val is_closed : t -> bool
-    (** [is_closed t] is [true] if {!close} has been called on [t] and [false]
-        otherwise. A closed [t] may still have pending output. *)
+    (** [is_closed t] is [true] if {!close} has been called on [t], or if the attached
+        output channel is closed (e.g. because [report_write_result `Closed] has been
+        called). A closed [t] may still have pending output. *)
   end
 
 end

--- a/lib/httpaf.mli
+++ b/lib/httpaf.mli
@@ -497,7 +497,7 @@ module Body : sig
         modified until a subsequent call to {!flush} has successfully
         completed. *)
 
-    val flush : t -> (unit -> unit) -> unit
+    val flush : t -> ([ `Written | `Closed ] -> unit) -> unit
     (** [flush t f] makes all bytes in [t] available for writing to the awaiting
         output channel. Once those bytes have reached that output channel, [f]
         will be called.

--- a/lib/reqd.ml
+++ b/lib/reqd.ml
@@ -162,10 +162,7 @@ let unsafe_respond_with_streaming ~flush_headers_immediately t response =
       | `Error (`Bad_gateway | `Internal_server_error) ->
         failwith "httpaf.Reqd.respond_with_streaming: invalid response body length"
     in
-    let response_body =
-      Body.Writer.create t.response_body_buffer ~encoding ~when_ready_to_write:(fun () ->
-        Writer.wakeup t.writer)
-    in
+    let response_body = Body.Writer.create t.response_body_buffer t.writer ~encoding in
     Writer.write_response t.writer response;
     if t.persistent then
       t.persistent <- Response.persistent_connection response;
@@ -256,6 +253,5 @@ let flush_request_body t =
 
 let flush_response_body t =
   match t.response_state with
-  | Streaming (_, response_body) ->
-    Body.Writer.transfer_to_writer response_body t.writer
+  | Streaming (_, response_body) -> Body.Writer.transfer_to_writer response_body
   | _ -> ()

--- a/lib/serialize.ml
+++ b/lib/serialize.ml
@@ -161,8 +161,8 @@ module Writer = struct
     flush_with_reason t.encoder (fun reason ->
       let result =
         match reason with
-        | `Nothing_pending | `Shift -> `Written
-        | `Drain -> `Closed
+        | Nothing_pending | Shift -> `Written
+        | Drain -> `Closed
       in
       f result)
 

--- a/lib/serialize.ml
+++ b/lib/serialize.ml
@@ -89,18 +89,18 @@ let schedule_bigstring_chunk t chunk =
 module Writer = struct
   type t =
     { buffer                : Bigstringaf.t
-      (* The buffer that the encoder uses for buffered writes. Managed by the
-       * control module for the encoder. *)
+    (* The buffer that the encoder uses for buffered writes. Managed by the
+     * control module for the encoder. *)
     ; encoder               : Faraday.t
-      (* The encoder that handles encoding for writes. Uses the [buffer]
-       * referenced above internally. *)
+    (* The encoder that handles encoding for writes. Uses the [buffer]
+     * referenced above internally. *)
     ; mutable drained_bytes : int
-      (* The number of bytes that were not written due to the output stream
-       * being closed before all buffered output could be written. Useful for
-       * detecting error cases. *)
+    (* The number of bytes that were not written due to the output stream
+     * being closed before all buffered output could be written. Useful for
+     * detecting error cases. *)
     ; mutable wakeup        : Optional_thunk.t
-      (* The callback from the runtime to be invoked when output is ready to be
-       * flushed. *)
+    (* The callback from the runtime to be invoked when output is ready to be
+     * flushed. *)
     }
 
   let create ?(buffer_size=0x800) () =
@@ -158,13 +158,19 @@ module Writer = struct
   ;;
 
   let flush t f =
-    flush t.encoder f
+    flush_with_reason t.encoder (fun reason ->
+      let result =
+        match reason with
+        | `Nothing_pending | `Shift -> `Written
+        | `Drain -> `Closed
+      in
+      f result)
 
   let unyield t =
     (* This would be better implemented by a function that just takes the
        encoder out of a yielded state if it's in that state. Requires a change
        to the faraday library. *)
-    flush t (fun () -> ())
+    flush t (fun _result -> ())
 
   let yield t =
     Faraday.yield t.encoder

--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -197,8 +197,7 @@ let set_error_and_handle ?request t error =
         | `Error (`Bad_gateway | `Internal_server_error) ->
           failwith "httpaf.Server_connection.error_handler: invalid response body length"
       in
-      Body.Writer.of_faraday (Writer.faraday writer) ~encoding
-        ~when_ready_to_write:(fun () -> Writer.wakeup writer));
+      Body.Writer.of_faraday (Writer.faraday writer) writer ~encoding);
   end
 
 let report_exn t exn =

--- a/lib_test/test_server_connection.ml
+++ b/lib_test/test_server_connection.ml
@@ -686,7 +686,7 @@ let test_chunked_encoding () =
     let resp_body = Reqd.respond_with_streaming reqd response in
     Body.Writer.write_string resp_body "First chunk";
     Body.Writer.flush resp_body (function
-      | `Closed -> ()
+      | `Closed -> assert false
       | `Written ->
         Body.Writer.write_string resp_body "Second chunk";
         Body.Writer.close resp_body);
@@ -766,13 +766,9 @@ let test_body_writing_when_socket_closes () =
   writer_yielded t;
   read_request t (Request.create `GET "/");
 
-  let (flush_result_testable : [ `Closed | `Written ] Alcotest.testable) = (module struct
-    type t = [ `Closed | `Written ]
-    let pp = Fmt.using (function `Closed -> "Closed" | `Written -> "Written") Fmt.string
-    let equal t t' =
-      match t, t' with
-      | `Closed, `Closed | `Written, `Written -> true
-      | _ -> false end)
+  let flush_result_testable =
+    Alcotest.of_pp
+      (Fmt.using (function `Closed -> "Closed" | `Written -> "Written") Fmt.string)
   in
 
   let body = Option.get !body_ref in


### PR DESCRIPTION
Currently, if you are writing to a body in a streaming manner, and the writer becomes closed, then you have to be careful to not write any more to the body. In practice this can be hard to achieve because your application-level code is probably the one writing to the body and your runtime / network-level code is the one that calls ``report_write_result `Closed``.

This PR therefore makes it safe to write to a body after the attached writer is closed. Those writes are simply ignored.

The user has two ways of discovering whether their writes are actually going to be processed or not:

* They can look at `Body.is_closed`, which now returns true if we've detected that the attached writer is closed, in addition to returning true if `Body.closed` has been called.
* The type of `Body.flush` has been augmented so that the callback is told whether the bytes successfully made it out of the writer, or were dropped on the floor. I.e. it has type ``val Body.flush : Body.t -> ([ `Closed | `Written ] -> unit) -> unit``.