### PR TITLE
give the body direct access to its sink writer

### DIFF
--- a/lib/client_connection.ml
+++ b/lib/client_connection.ml
@@ -72,7 +72,7 @@ module Oneshot = struct
           failwith "Httpaf.Client_connection.request: invalid body length"
       in
       Body.Writer.create (Bigstringaf.create config.request_body_buffer_size)
-        ~encoding ~when_ready_to_write:(fun () -> Writer.wakeup writer)
+        ~encoding ~writer
     in
     let t =
       { request
@@ -89,7 +89,7 @@ module Oneshot = struct
 
   let flush_request_body t =
     if Body.Writer.has_pending_output t.request_body
-    then Body.Writer.transfer_to_writer t.request_body t.writer
+    then Body.Writer.transfer_to_writer t.request_body
   ;;
 
   let set_error_and_handle_without_shutdown t error =

--- a/lib/reqd.ml
+++ b/lib/reqd.ml
@@ -163,8 +163,7 @@ let unsafe_respond_with_streaming ~flush_headers_immediately t response =
         failwith "httpaf.Reqd.respond_with_streaming: invalid response body length"
     in
     let response_body =
-      Body.Writer.create t.response_body_buffer ~encoding ~when_ready_to_write:(fun () ->
-        Writer.wakeup t.writer)
+      Body.Writer.create t.response_body_buffer ~encoding ~writer:t.writer
     in
     Writer.write_response t.writer response;
     if t.persistent then
@@ -257,5 +256,5 @@ let flush_request_body t =
 let flush_response_body t =
   match t.response_state with
   | Streaming (_, response_body) ->
-    Body.Writer.transfer_to_writer response_body t.writer
+    Body.Writer.transfer_to_writer response_body
   | _ -> ()

--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -200,8 +200,7 @@ let set_error_and_handle ?request t error =
         | `Error (`Bad_gateway | `Internal_server_error) ->
           failwith "httpaf.Server_connection.error_handler: invalid response body length"
       in
-      Body.Writer.of_faraday (Writer.faraday writer) ~encoding
-        ~when_ready_to_write:(fun () -> Writer.wakeup writer));
+      Body.Writer.create_direct ~encoding ~writer);
   end
 
 let report_exn t exn =


### PR DESCRIPTION
We normally indirectly gain access to the writer in two ways: one is
through the `when_ready_to_write` callback, and the other through
`transfer_to_writer` as an argument. Instead, just give the writer to
the body writer directly but continue to drive it from the outside.

This is mostly a simple refactor, but it gives us the ability to do
something smarter in another branch, which is to query the writer to see
if a flush will succeed or not and report back to the user so they can
act appropriately.