### PR TITLE
remove references to result package

### DIFF
--- a/httpaf.opam
+++ b/httpaf.opam
@@ -17,7 +17,6 @@ depends: [
   "bigstringaf" {>= "0.4.0"}
   "angstrom" {>= "0.14.0"}
   "faraday"  {>= "0.6.1"}
-  "result"
 ]
 synopsis:
   "A high-performance, memory-efficient, and scalable web server for OCaml"

--- a/lib/dune
+++ b/lib/dune
@@ -2,5 +2,5 @@
  (name        httpaf)
  (public_name httpaf)
  (libraries
-   angstrom faraday bigstringaf result)
+   angstrom faraday bigstringaf)
  (flags (:standard -safe-string)))

--- a/lib/httpaf.mli
+++ b/lib/httpaf.mli
@@ -41,9 +41,6 @@
     1.1 specification, and the basic principles of memory management and
     vectorized IO. *)
 
-
-open Result
-
 (** {2 Basic HTTP Types} *)
 
 

--- a/lib/reqd.ml
+++ b/lib/reqd.ml
@@ -215,7 +215,7 @@ let report_error t error =
 let report_exn t exn =
   report_error t (`Exn exn)
 
-let try_with t f : (unit, exn) Result.result =
+let try_with t f : (unit, exn) result =
   try f (); Ok () with exn -> report_exn t exn; Error exn
 
 (* Private API, not exposed to the user through httpaf.mli *)


### PR DESCRIPTION
This was integrated into stdlib in 4.03, which is the earliest version we support. Fixes #221.