### PR TITLE
fix-zero-chunk-end-of-request: finish after eol consumed

### DIFF
--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -191,7 +191,7 @@ let body ~encoding body =
       in
       _hex >>= fun size ->
       if size = 0L
-      then eol *> finish body
+      then eol >>= fun _eol -> finish body
       else fixed size ~unexpected:"expected more from body chunk" *> eol *> p)
   | `Close_delimited ->
     fix (fun p ->

--- a/lib_test/test_server_connection.ml
+++ b/lib_test/test_server_connection.ml
@@ -413,7 +413,7 @@ let test_echo_post () =
   write_response t
     ~body:"e\r\nThis is a test\r\n"
     response;
-  read_string  t "\r\n0\r\n";
+  read_string  t "\r\n0\r\n\r\n";
   write_string t "0\r\n\r\n";
   writer_yielded t;
 
@@ -427,7 +427,7 @@ let test_echo_post () =
     response;
   read_string  t "\r\n21\r\n... that involves multiple chunks";
   write_string t "21\r\n... that involves multiple chunks\r\n";
-  read_string  t "\r\n0\r\n";
+  read_string  t "\r\n0\r\n\r\n";
   write_string t "0\r\n\r\n";
   writer_yielded t;
 
@@ -442,7 +442,7 @@ let test_echo_post () =
     ~body:"This is a test"
     response;
   read_string  t "\r\n21\r\n... that involves multiple chunks";
-  read_string  t "\r\n0\r\n";
+  read_string  t "\r\n0\r\n\r\n";
   write_string t "... that involves multiple chunks";
   connection_is_shutdown t;
 ;;


### PR DESCRIPTION
finsh has side effects so ensure that the parser on the lhs of the sequence operator has consumed its input before calling it.