### PR TITLE
export buffer in async

### DIFF
--- a/async/httpaf_async.mli
+++ b/async/httpaf_async.mli
@@ -3,6 +3,15 @@ open Async
 
 open Httpaf
 
+module Buffer : sig
+  type t
+
+  val create   : int -> t
+
+  val get : t -> f:(Bigstring.t -> off:int -> len:int -> int) -> int
+  val put : t -> f:(Bigstring.t -> off:int -> len:int -> int) -> int
+end
+
 module Server : sig
   val create_connection_handler
     :  ?config         : Config.t

--- a/httpaf.opam
+++ b/httpaf.opam
@@ -17,7 +17,6 @@ depends: [
   "bigstringaf" {>= "0.4.0"}
   "angstrom" {>= "0.14.0"}
   "faraday"  {>= "0.6.1"}
-  "result"
 ]
 synopsis:
   "A high-performance, memory-efficient, and scalable web server for OCaml"

--- a/lib/dune
+++ b/lib/dune
@@ -2,5 +2,5 @@
  (name        httpaf)
  (public_name httpaf)
  (libraries
-   angstrom faraday bigstringaf result)
+   angstrom faraday bigstringaf)
  (flags (:standard -safe-string)))

--- a/lib/httpaf.mli
+++ b/lib/httpaf.mli
@@ -41,9 +41,6 @@
     1.1 specification, and the basic principles of memory management and
     vectorized IO. *)
 
-
-open Result
-
 (** {2 Basic HTTP Types} *)
 
 

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -191,7 +191,7 @@ let body ~encoding body =
       in
       _hex >>= fun size ->
       if size = 0L
-      then eol *> finish body
+      then eol >>= fun _eol -> finish body
       else fixed size ~unexpected:"expected more from body chunk" *> eol *> p)
   | `Close_delimited ->
     fix (fun p ->

--- a/lib/reqd.ml
+++ b/lib/reqd.ml
@@ -215,7 +215,7 @@ let report_error t error =
 let report_exn t exn =
   report_error t (`Exn exn)
 
-let try_with t f : (unit, exn) Result.result =
+let try_with t f : (unit, exn) result =
   try f (); Ok () with exn -> report_exn t exn; Error exn
 
 (* Private API, not exposed to the user through httpaf.mli *)

--- a/lib_test/test_server_connection.ml
+++ b/lib_test/test_server_connection.ml
@@ -413,7 +413,7 @@ let test_echo_post () =
   write_response t
     ~body:"e\r\nThis is a test\r\n"
     response;
-  read_string  t "\r\n0\r\n";
+  read_string  t "\r\n0\r\n\r\n";
   write_string t "0\r\n\r\n";
   writer_yielded t;
 
@@ -427,7 +427,7 @@ let test_echo_post () =
     response;
   read_string  t "\r\n21\r\n... that involves multiple chunks";
   write_string t "21\r\n... that involves multiple chunks\r\n";
-  read_string  t "\r\n0\r\n";
+  read_string  t "\r\n0\r\n\r\n";
   write_string t "0\r\n\r\n";
   writer_yielded t;
 
@@ -442,7 +442,7 @@ let test_echo_post () =
     ~body:"This is a test"
     response;
   read_string  t "\r\n21\r\n... that involves multiple chunks";
-  read_string  t "\r\n0\r\n";
+  read_string  t "\r\n0\r\n\r\n";
   write_string t "... that involves multiple chunks";
   connection_is_shutdown t;
 ;;


### PR DESCRIPTION
Hi, the `Buffer` module in `httpaf_async.ml` is quite useful, in fact I'm using it in my [http client](https://github.com/crackcomm/ocaml-http-client/blob/main/http_client/conn.ml#L149-L162) but it requires this patch which provides interface to make the module public.

Maybe there is a replacement in `Core` or otherwise maybe you want to move it to another library (although `Httpaf_async.Buffer` works for me in given context).

Thanks.