### PR TITLE
Upstream Jane Street Changes

### DIFF
--- a/lib/client_connection.ml
+++ b/lib/client_connection.ml
@@ -31,12 +31,15 @@
     POSSIBILITY OF SUCH DAMAGE.
   ----------------------------------------------------------------------------*)
 
+open Sexplib.Std
+
 module Reader = Parse.Reader
 module Writer = Serialize.Writer
 
 module Oneshot = struct
   type error =
     [ `Malformed_response of string | `Invalid_response_body_length of Response.t | `Exn of exn ]
+  [@@deriving sexp_of]
 
   type response_handler = Response.t -> Body.Reader.t  -> unit
   type error_handler = error -> unit

--- a/lib/dune
+++ b/lib/dune
@@ -1,6 +1,6 @@
 (library
  (name        httpaf)
  (public_name httpaf)
- (libraries angstrom faraday bigstringaf base sexplib)
+ (libraries angstrom faraday bigstringaf sexplib)
  (preprocess (pps ppx_sexp_conv))
  (flags (:standard -safe-string)))

--- a/lib/dune
+++ b/lib/dune
@@ -1,6 +1,6 @@
 (library
  (name        httpaf)
  (public_name httpaf)
- (libraries
-   angstrom faraday bigstringaf)
+ (libraries angstrom faraday bigstringaf base sexplib)
+ (preprocess (pps ppx_sexp_conv))
  (flags (:standard -safe-string)))

--- a/lib/headers.ml
+++ b/lib/headers.ml
@@ -31,10 +31,14 @@
     POSSIBILITY OF SUCH DAMAGE.
   ----------------------------------------------------------------------------*)
 
+open Sexplib.Std
 
-type name = string
-type value = string
-type t = (name * value) list
+
+type name = string [@@deriving sexp]
+type value = string [@@deriving sexp]
+type t = (name * value) list [@@deriving sexp]
+
+let sexp_of_t t = sexp_of_t (List.rev t)
 
 let empty : t = []
 
@@ -70,6 +74,7 @@ module CI = struct
       done;
       !equal_so_far
     )
+  ;;
 end
 
 let ci_equal = CI.equal

--- a/lib/headers.mli
+++ b/lib/headers.mli
@@ -1,4 +1,4 @@
-type t
+type t [@@deriving sexp]
 
 type name = string
 type value = string
@@ -30,4 +30,4 @@ val iter : f:(name -> value -> unit) -> t -> unit
 val fold : f:(name -> value -> 'a -> 'a) -> init:'a -> t -> 'a
 
 val to_string : t -> string
-val pp_hum : Format.formatter -> t -> unit [@@ocaml.toplevel_printer]
+val pp_hum : Format.formatter -> t -> unit

--- a/lib/headers.mli
+++ b/lib/headers.mli
@@ -30,4 +30,4 @@ val iter : f:(name -> value -> unit) -> t -> unit
 val fold : f:(name -> value -> 'a -> 'a) -> init:'a -> t -> 'a
 
 val to_string : t -> string
-val pp_hum : Format.formatter -> t -> unit
+val pp_hum : Format.formatter -> t -> unit [@@ocaml.toplevel_printer]

--- a/lib/httpaf.mli
+++ b/lib/httpaf.mli
@@ -67,7 +67,7 @@ module Version : sig
   val to_string : t -> string
   val of_string : string -> t
 
-  val pp_hum : Format.formatter -> t -> unit
+  val pp_hum : Format.formatter -> t -> unit [@@ocaml.toplevel_printer]
 end
 
 
@@ -136,7 +136,7 @@ module Method : sig
   val to_string : t -> string
   val of_string : string -> t
 
-  val pp_hum : Format.formatter -> t -> unit
+  val pp_hum : Format.formatter -> t -> unit [@@ocaml.toplevel_printer]
 end
 
 
@@ -300,7 +300,7 @@ module Status : sig
   val to_string : t -> string
   val of_string : string -> t
 
-  val pp_hum : Format.formatter -> t -> unit
+  val pp_hum : Format.formatter -> t -> unit [@@ocaml.toplevel_printer]
 end
 
 
@@ -450,7 +450,7 @@ module Headers : sig
 
   val to_string : t -> string
 
-  val pp_hum : Format.formatter -> t -> unit
+  val pp_hum : Format.formatter -> t -> unit [@@ocaml.toplevel_printer]
 end
 
 (** {2 Message Body} *)
@@ -579,7 +579,7 @@ module Request : sig
       See {{:https://tools.ietf.org/html/rfc7230#section-6.3} RFC7230§6.3 for
       more details. *)
 
-  val pp_hum : Format.formatter -> t -> unit
+  val pp_hum : Format.formatter -> t -> unit [@@ocaml.toplevel_printer]
 end
 
 
@@ -632,7 +632,7 @@ module Response : sig
       See {{:https://tools.ietf.org/html/rfc7230#section-6.3} RFC7230§6.3 for
       more details. *)
 
-  val pp_hum : Format.formatter -> t -> unit
+  val pp_hum : Format.formatter -> t -> unit [@@ocaml.toplevel_printer]
 end
 
 
@@ -649,7 +649,7 @@ module IOVec : sig
   val shift  : 'a t -> int -> 'a t
   val shiftv : 'a t list -> int -> 'a t list
 
-  val pp_hum : Format.formatter -> _ t -> unit
+  val pp_hum : Format.formatter -> _ t -> unit [@@ocaml.toplevel_printer]
 end
 
 (** {2 Request Descriptor} *)

--- a/lib/method.ml
+++ b/lib/method.ml
@@ -31,6 +31,7 @@
     POSSIBILITY OF SUCH DAMAGE.
   ----------------------------------------------------------------------------*)
 
+open Sexplib.Std
 
 type standard =  [
   | `GET
@@ -42,11 +43,13 @@ type standard =  [
   | `OPTIONS
   | `TRACE
 ]
+[@@deriving sexp]
 
 type t = [
   | standard
   | `Other of string
   ]
+[@@deriving sexp]
 
 let is_safe = function
   | `GET | `HEAD | `OPTIONS | `TRACE -> true

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -31,7 +31,6 @@
     POSSIBILITY OF SUCH DAMAGE.
   ----------------------------------------------------------------------------*)
 
-
 include Angstrom
 
 module P = struct
@@ -139,7 +138,7 @@ let response =
   lift4 (fun version status reason headers ->
     Response.create ~reason ~version ~headers status)
     (version              <* char ' ')
-    (status               <* char ' ')
+    (status               <* option ' ' (char ' '))
     (take_till P.is_cr    <* eol <* commit)
     (headers              <* eol)
 
@@ -149,9 +148,6 @@ let finish body =
 
 let schedule_size body n =
   let faraday = Body.Reader.unsafe_faraday body in
-  (* XXX(seliopou): performance regression due to switching to a single output
-   * format in Farady. Once a specialized operation is exposed to avoid the
-   * intemediate copy, this should be back to the original performance. *)
   begin if Faraday.is_closed faraday
   then advance n
   else take n >>| fun s -> Faraday.write_string faraday s

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -31,6 +31,7 @@
     POSSIBILITY OF SUCH DAMAGE.
   ----------------------------------------------------------------------------*)
 
+
 include Angstrom
 
 module P = struct
@@ -148,6 +149,9 @@ let finish body =
 
 let schedule_size body n =
   let faraday = Body.Reader.unsafe_faraday body in
+  (* XXX(seliopou): performance regression due to switching to a single output
+   * format in Farady. Once a specialized operation is exposed to avoid the
+   * intemediate copy, this should be back to the original performance. *)
   begin if Faraday.is_closed faraday
   then advance n
   else take n >>| fun s -> Faraday.write_string faraday s

--- a/lib/reqd.ml
+++ b/lib/reqd.ml
@@ -37,14 +37,17 @@ type error =
 module Response_state = struct
   type t =
     | Waiting
+    | Upgrade of Response.t
     | Fixed     of Response.t
     | Streaming of Response.t * Body.Writer.t
 end
 
 module Input_state = struct
   type t =
+    | Waiting
     | Ready
     | Complete
+    | Upgraded
 end
 
 module Output_state = struct
@@ -52,6 +55,7 @@ module Output_state = struct
     | Waiting
     | Ready
     | Complete
+    | Upgraded
 end
 
 type error_handler =
@@ -111,12 +115,14 @@ let response { response_state; _ } =
   match response_state with
   | Waiting -> None
   | Streaming (response, _)
+  | Upgrade response
   | Fixed response -> Some response
 
 let response_exn { response_state; _ } =
   match response_state with
   | Waiting -> failwith "httpaf.Reqd.response_exn: response has not started"
   | Streaming (response, _)
+  | Upgrade response
   | Fixed response -> response
 
 let respond_with_string t response str =
@@ -133,6 +139,7 @@ let respond_with_string t response str =
     Writer.wakeup t.writer;
   | Streaming _ ->
     failwith "httpaf.Reqd.respond_with_string: response already started"
+  | Upgrade _
   | Fixed _ ->
     failwith "httpaf.Reqd.respond_with_string: response already complete"
 
@@ -150,6 +157,7 @@ let respond_with_bigstring t response (bstr:Bigstringaf.t) =
     Writer.wakeup t.writer;
   | Streaming _ ->
     failwith "httpaf.Reqd.respond_with_bigstring: response already started"
+  | Upgrade _
   | Fixed _ ->
     failwith "httpaf.Reqd.respond_with_bigstring: response already complete"
 
@@ -175,6 +183,7 @@ let unsafe_respond_with_streaming ~flush_headers_immediately t response =
     response_body
   | Streaming _ ->
     failwith "httpaf.Reqd.respond_with_streaming: response already started"
+  | Upgrade _
   | Fixed _ ->
     failwith "httpaf.Reqd.respond_with_streaming: response already complete"
 
@@ -182,6 +191,23 @@ let respond_with_streaming ?(flush_headers_immediately=false) t response =
   if t.error_code <> `Ok then
     failwith "httpaf.Reqd.respond_with_streaming: invalid state, currently handling error";
   unsafe_respond_with_streaming ~flush_headers_immediately t response
+
+let respond_with_upgrade ?reason t headers =
+  match t.response_state with
+  | Waiting ->
+    if not (Request.is_upgrade t.request) then
+      failwith "httpaf.Reqd.respond_with_upgrade: request was not an upgrade request"
+    else (
+      let response = Response.create ?reason ~headers `Switching_protocols in
+      t.response_state <- Upgrade response;
+      Body.Reader.close t.request_body;
+      Writer.write_response t.writer response;
+      Writer.wakeup t.writer);
+  | Streaming _ ->
+    failwith "httpaf.Reqd.respond_with_upgrade: response already started"
+  | Upgrade _
+  | Fixed _ ->
+    failwith "httpaf.Reqd.respond_with_upgrade: response already complete"
 
 let report_error t error =
   t.persistent <- false;
@@ -207,7 +233,7 @@ let report_error t error =
   | Streaming (_response, response_body), `Exn _ ->
     Body.Writer.close response_body;
     Writer.close_and_drain t.writer
-  | (Fixed _ | Streaming _ | Waiting) , _ ->
+  | (Fixed _ | Streaming _ | Waiting | Upgrade _) , _ ->
     (* XXX(seliopou): Once additional logging support is added, log the error
      * in case it is not spurious. *)
     ()
@@ -215,7 +241,7 @@ let report_error t error =
 let report_exn t exn =
   report_error t (`Exn exn)
 
-let try_with t f : (unit, exn) result =
+let try_with t f : (unit, exn) Result.t =
   try f (); Ok () with exn -> report_exn t exn; Error exn
 
 (* Private API, not exposed to the user through httpaf.mli *)
@@ -232,21 +258,41 @@ let persistent_connection t =
   t.persistent
 
 let input_state t : Input_state.t =
-  if Body.Reader.is_closed t.request_body
-  then Complete
-  else Ready
+  let upgrade_status =
+    match Request.is_upgrade t.request with
+    | false -> `Not_upgrading
+    | true ->
+      match t.response_state with
+      | Upgrade _ -> `Finished_upgrading
+      | Fixed _ | Streaming _ -> `Upgrade_declined
+      | Waiting -> `Upgrade_in_progress
+  in
+  match upgrade_status with
+  | `Finished_upgrading -> Upgraded
+  | `Not_upgrading | `Upgrade_declined ->
+    if Body.Reader.is_closed t.request_body
+    then Complete
+    else Ready
+  | `Upgrade_in_progress ->
+    Waiting
 ;;
 
 let output_state t : Output_state.t =
   match t.response_state with
+  | Upgrade _ -> Upgraded
   | Fixed _ -> Complete
   | Streaming (_, response_body) ->
-    if Body.Writer.has_pending_output response_body
+    if Writer.is_closed t.writer
+    then Complete
+    else if Body.Writer.has_pending_output response_body
     then Ready
     else if Body.Writer.is_closed response_body
     then Complete
     else Waiting
-  | Waiting -> Waiting
+  | Waiting ->
+    if Writer.is_closed t.writer
+    then Complete
+    else Waiting
 ;;
 
 let flush_request_body t =

--- a/lib/request.ml
+++ b/lib/request.ml
@@ -31,11 +31,14 @@
     POSSIBILITY OF SUCH DAMAGE.
   ----------------------------------------------------------------------------*)
 
+open Sexplib.Std
+
 type t =
   { meth    : Method.t
   ; target  : string
   ; version : Version.t
   ; headers : Headers.t }
+[@@deriving sexp]
 
 let create ?(version=Version.v1_1) ?(headers=Headers.empty) meth target =
   { meth; target; version; headers }
@@ -80,3 +83,8 @@ let persistent_connection ?proxy { version; headers; _ } =
 let pp_hum fmt { meth; target; version; headers } =
   Format.fprintf fmt "((method \"%a\") (target %S) (version \"%a\") (headers %a))"
     Method.pp_hum meth target Version.pp_hum version Headers.pp_hum headers
+
+let is_upgrade t =
+  match Headers.get t.headers "Connection" with
+  | None -> false
+  | Some header_val -> Headers.ci_equal header_val "upgrade"

--- a/lib/response.ml
+++ b/lib/response.ml
@@ -31,11 +31,14 @@
     POSSIBILITY OF SUCH DAMAGE.
   ----------------------------------------------------------------------------*)
 
+open Sexplib.Std
+
 type t =
   { version : Version.t
   ; status  : Status.t
   ; reason  : string
   ; headers : Headers.t }
+[@@deriving sexp]
 
 let create ?reason ?(version=Version.v1_1) ?(headers=Headers.empty) status =
   let reason =

--- a/lib/serialize.ml
+++ b/lib/serialize.ml
@@ -195,4 +195,6 @@ module Writer = struct
     | `Close         -> `Close (drained_bytes t)
     | `Yield         -> `Yield
     | `Writev iovecs -> `Write iovecs
+
+  let has_pending_output t = Faraday.has_pending_output t.encoder
 end

--- a/lib/status.ml
+++ b/lib/status.ml
@@ -31,11 +31,13 @@
     POSSIBILITY OF SUCH DAMAGE.
   ----------------------------------------------------------------------------*)
 
+open Sexplib.Std
 
 type informational = [
   | `Continue
   | `Switching_protocols
   ]
+[@@deriving sexp]
 
 type successful = [
   | `OK
@@ -46,6 +48,7 @@ type successful = [
   | `Reset_content
   | `Partial_content
   ]
+[@@deriving sexp]
 
 type redirection = [
   | `Multiple_choices
@@ -56,6 +59,7 @@ type redirection = [
   | `Use_proxy
   | `Temporary_redirect
   ]
+[@@deriving sexp]
 
 type client_error = [
   | `Bad_request
@@ -80,6 +84,7 @@ type client_error = [
   | `Enhance_your_calm
   | `Upgrade_required
   ]
+[@@deriving sexp]
 
 type server_error = [
   | `Internal_server_error
@@ -89,6 +94,7 @@ type server_error = [
   | `Gateway_timeout
   | `Http_version_not_supported
   ]
+[@@deriving sexp]
 
 type standard = [
   | informational
@@ -97,10 +103,12 @@ type standard = [
   | client_error
   | server_error
   ]
+[@@deriving sexp]
 
 type t = [
   | standard
   | `Code of int ]
+[@@deriving sexp]
 
 let default_reason_phrase = function
  (* Informational *)

--- a/lib/version.ml
+++ b/lib/version.ml
@@ -31,10 +31,12 @@
     POSSIBILITY OF SUCH DAMAGE.
   ----------------------------------------------------------------------------*)
 
+open Sexplib.Std
 
 type t =
   { major : int
   ; minor : int }
+[@@deriving sexp]
 
 let v1_0 = { major = 1; minor = 0 }
 let v1_1 = { major = 1; minor = 1 }


### PR DESCRIPTION
Jane Streets internal copy of httpaf has accumulated some changes that we'd like to upstream to prevent further divergence.  These changes mostly involve support for upgrading connections to support websockets, and adding sexp derivers for many types.  

This PR is mainly here to collect all the changes, and we might want to split them up into smaller, more targeted PRS. 